### PR TITLE
Refactor RadixAddress and particle owner checks

### DIFF
--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/address/RadixAddress.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/address/RadixAddress.java
@@ -6,6 +6,7 @@ import com.radixdlt.client.core.crypto.ECKeyPair;
 import com.radixdlt.client.core.crypto.ECPublicKey;
 import com.radixdlt.client.core.util.Base58;
 import com.radixdlt.client.core.util.Hash;
+import java.util.Objects;
 
 public class RadixAddress {
 
@@ -31,17 +32,18 @@ public class RadixAddress {
 	}
 
 	public RadixAddress(RadixUniverseConfig universe, ECPublicKey publicKey) {
-		if (publicKey == null) {
-			throw new IllegalArgumentException();
-		}
+		this(universe.getMagic(), publicKey);
+	}
 
+	public RadixAddress(int magic, ECPublicKey publicKey) {
+		Objects.requireNonNull(publicKey);
 		if (publicKey.length() != 33) {
 			throw new IllegalArgumentException("Public key must be 33 bytes but was " + publicKey.length());
 		}
 
 		byte[] addressBytes = new byte[1 + publicKey.length() + 4];
 		// Universe magic byte
-		addressBytes[0] = (byte) (universe.getMagic() & 0xff);
+		addressBytes[0] = (byte) (magic & 0xff);
 		// Public Key
 		publicKey.copyPublicKey(addressBytes, 1);
 		// Checksum
@@ -52,6 +54,13 @@ public class RadixAddress {
 		this.publicKey = publicKey;
 	}
 
+	public boolean ownsKey(ECKeyPair ecKeyPair) {
+		return this.ownsKey(ecKeyPair.getPublicKey());
+	}
+
+	public boolean ownsKey(ECPublicKey publicKey) {
+		return this.publicKey.equals(publicKey);
+	}
 
 	@Override
 	public String toString() {

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/Particle.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/Particle.java
@@ -7,6 +7,7 @@ import com.radixdlt.client.core.crypto.ECKeyPair;
 import com.radixdlt.client.core.crypto.ECPublicKey;
 import com.radixdlt.client.core.serialization.Dson;
 import com.radixdlt.client.core.util.Hash;
+import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -29,21 +30,12 @@ public abstract class Particle {
 		this.owners = owners;
 	}
 
-	public boolean hasOwner(ECPublicKey publicKey) {
-		// TODO: optimize this
-		return this.owners != null && this.owners.stream().map(ECKeyPair::getPublicKey).allMatch(pb -> pb.equals(publicKey));
-	}
-
 	public Set<EUID> getDestinations() {
 		return destinations;
 	}
 
 	public Set<ECPublicKey> getOwners() {
-		return owners.stream().map(ECKeyPair::getPublicKey).collect(Collectors.toSet());
-	}
-
-	public Set<RadixAddress> getOwnersByAddress(RadixUniverseConfig universe) {
-		return owners.stream().map(ecKeyPair -> new RadixAddress(universe, ecKeyPair.getPublicKey())).collect(Collectors.toSet());
+		return owners == null ? Collections.emptySet() : owners.stream().map(ECKeyPair::getPublicKey).collect(Collectors.toSet());
 	}
 
 	public boolean isAbstractConsumable() {

--- a/radixdlt-java/src/main/java/com/radixdlt/client/wallet/TransactionAtoms.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/wallet/TransactionAtoms.java
@@ -1,21 +1,16 @@
 package com.radixdlt.client.wallet;
 
-import com.radixdlt.client.core.RadixUniverse;
 import com.radixdlt.client.core.address.EUID;
 import com.radixdlt.client.core.address.RadixAddress;
 import com.radixdlt.client.core.atoms.AbstractConsumable;
 import com.radixdlt.client.core.atoms.Consumable;
 import com.radixdlt.client.core.atoms.Particle;
-import com.radixdlt.client.core.atoms.RadixHash;
 import com.radixdlt.client.core.atoms.TransactionAtom;
-import com.radixdlt.client.core.crypto.ECPublicKey;
 import io.reactivex.ObservableEmitter;
 import io.reactivex.observables.ConnectableObservable;
 import java.nio.ByteBuffer;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
@@ -54,7 +49,7 @@ public class TransactionAtoms {
 		transactionAtom.getParticles().stream()
 			.filter(Particle::isAbstractConsumable)
 			.map(Particle::getAsAbstractConsumable)
-			.filter(particle -> particle.hasOwner(address.getPublicKey()))
+			.filter(particle -> particle.getOwners().stream().allMatch(address::ownsKey))
 			.filter(particle -> particle.getAssetId().equals(assetId))
 			.forEach(particle -> {
 				ByteBuffer dson = ByteBuffer.wrap(particle.getDson());
@@ -84,7 +79,7 @@ public class TransactionAtoms {
 		Optional<ByteBuffer> missing = transactionAtom.getParticles().stream()
 			.filter(Particle::isAbstractConsumable)
 			.map(Particle::getAsAbstractConsumable)
-			.filter(particle -> particle.hasOwner(address.getPublicKey()))
+			.filter(particle -> particle.getOwners().stream().allMatch(address::ownsKey))
 			.filter(particle -> particle.getAssetId().equals(assetId))
 			.filter(AbstractConsumable::isConsumer)
 			.map(AbstractConsumable::getDson)

--- a/radixdlt-java/src/main/java/com/radixdlt/client/wallet/WalletTransaction.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/wallet/WalletTransaction.java
@@ -21,7 +21,7 @@ public class WalletTransaction {
 				.filter(Particle::isAbstractConsumable)
 				.map(Particle::getAsAbstractConsumable)
 				.filter(particle -> particle.getAssetId().equals(Asset.XRD.getId()))
-				.filter(particle -> particle.hasOwner(address.getPublicKey()))
+				.filter(particle -> particle.getOwners().stream().allMatch(address::ownsKey))
 				.mapToLong(AbstractConsumable::signedQuantity)
 				.sum();
 

--- a/radixdlt-java/src/test/java/com/radixdlt/client/wallet/RadixWalletTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/wallet/RadixWalletTest.java
@@ -18,6 +18,7 @@ import com.radixdlt.client.core.identity.RadixIdentity;
 import com.radixdlt.client.core.ledger.RadixLedger;
 import com.radixdlt.client.core.address.RadixAddress;
 import io.reactivex.Observable;
+import java.security.interfaces.ECKey;
 import java.util.Collections;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -61,6 +62,8 @@ public class RadixWalletTest {
 		when(publicKey.toByteArray()).thenReturn(new byte[33]);
 		when(publicKey.length()).thenReturn(33);
 		when(address.getPublicKey()).thenReturn(publicKey);
+		when(address.ownsKey(any(ECPublicKey.class))).thenReturn(true);
+		when(address.ownsKey(any(ECKeyPair.class))).thenReturn(true);
 		when(ledger.getMagic()).thenReturn(1);
 
 		when(consumer.quantity()).thenReturn(1L);
@@ -75,7 +78,6 @@ public class RadixWalletTest {
 		when(consumable.getAsConsumable()).thenReturn(consumable);
 		when(consumable.isAbstractConsumable()).thenReturn(true);
 		when(consumable.getAsAbstractConsumable()).thenReturn(consumable);
-		when(consumable.hasOwner(any())).thenReturn(true);
 		when(transactionAtom.getParticles()).thenReturn(Collections.singletonList(consumable));
 		ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
 		when(ledger.getAllAtoms(any(), any())).thenReturn(Observable.create(emitter -> {

--- a/radixdlt-java/src/test/java/com/radixdlt/client/wallet/TransactionAtomsTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/wallet/TransactionAtomsTest.java
@@ -1,16 +1,21 @@
 package com.radixdlt.client.wallet;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.radixdlt.client.assets.Asset;
 import com.radixdlt.client.core.RadixUniverse;
+import com.radixdlt.client.core.address.RadixAddress;
 import com.radixdlt.client.core.atoms.AtomBuilder;
 import com.radixdlt.client.core.atoms.Consumable;
 import com.radixdlt.client.core.atoms.Consumer;
 import com.radixdlt.client.core.atoms.TransactionAtom;
 import com.radixdlt.client.core.atoms.UnsignedAtom;
+import com.radixdlt.client.core.crypto.ECKeyPair;
+import com.radixdlt.client.core.crypto.ECPublicKey;
 import com.radixdlt.client.core.identity.OneTimeUseIdentity;
 import org.junit.Test;
 
@@ -19,16 +24,17 @@ public class TransactionAtomsTest {
 	@Test
 	public void testConsumerWithNoConsumable() {
 		OneTimeUseIdentity radixIdentity = new OneTimeUseIdentity();
+		RadixAddress address = new RadixAddress(1, radixIdentity.getPublicKey());
 
 		/* Build atom with consumer originating from nowhere */
 		UnsignedAtom unsignedAtom = new AtomBuilder()
 			.type(TransactionAtom.class)
 			.addParticle(new Consumer(100, radixIdentity.getPublicKey().toECKeyPair(), 1, Asset.XRD.getId()))
 			.addParticle(new Consumable(100, radixIdentity.getPublicKey().toECKeyPair(), 2, Asset.XRD.getId()))
-			.buildWithPOWFee(RadixUniverse.getInstance().getLedger().getMagic(), radixIdentity.getPublicKey());
+			.buildWithPOWFee(1, radixIdentity.getPublicKey());
 
 		/* Make sure we don't count it unless we find the matching consumable */
-		TransactionAtoms transactionAtoms = new TransactionAtoms(RadixUniverse.getInstance().getAddressFrom(radixIdentity.getPublicKey()), Asset.XRD.getId());
+		TransactionAtoms transactionAtoms = new TransactionAtoms(address, Asset.XRD.getId());
 		transactionAtoms.accept(radixIdentity.synchronousSign(unsignedAtom).getAsTransactionAtom());
 		assertEquals(0, transactionAtoms.getUnconsumedConsumables().count());
 	}
@@ -38,21 +44,24 @@ public class TransactionAtomsTest {
 		OneTimeUseIdentity radixIdentity = new OneTimeUseIdentity();
 		OneTimeUseIdentity radixIdentity2 = new OneTimeUseIdentity();
 
-		/* Build atom with consumer originating from nowhere */
+		RadixAddress address = new RadixAddress(1, radixIdentity.getPublicKey());
+
+		/* Atom with consumer originating from nowhere */
 		UnsignedAtom unsignedAtom = new AtomBuilder()
 			.type(TransactionAtom.class)
 			.addParticle(new Consumer(100, radixIdentity.getPublicKey().toECKeyPair(), 1, Asset.XRD.getId()))
 			.addParticle(new Consumable(100, radixIdentity.getPublicKey().toECKeyPair(), 2, Asset.XRD.getId()))
-			.buildWithPOWFee(RadixUniverse.getInstance().getLedger().getMagic(), radixIdentity.getPublicKey());
+			.buildWithPOWFee(1, radixIdentity.getPublicKey());
 
+		/* Atom with consumable for previous atom's consumer */
 		UnsignedAtom unsignedAtom2 = new AtomBuilder()
 			.type(TransactionAtom.class)
 			.addParticle(new Consumer(100, radixIdentity2.getPublicKey().toECKeyPair(), 1, Asset.XRD.getId()))
 			.addParticle(new Consumable(100, radixIdentity.getPublicKey().toECKeyPair(), 1, Asset.XRD.getId()))
-			.buildWithPOWFee(RadixUniverse.getInstance().getLedger().getMagic(), radixIdentity.getPublicKey());
+			.buildWithPOWFee(1, radixIdentity.getPublicKey());
 
 		/* Make sure we don't count it unless we find the matching consumable */
-		TransactionAtoms transactionAtoms = new TransactionAtoms(RadixUniverse.getInstance().getAddressFrom(radixIdentity.getPublicKey()), Asset.XRD.getId());
+		TransactionAtoms transactionAtoms = new TransactionAtoms(address, Asset.XRD.getId());
 		transactionAtoms.accept(radixIdentity.synchronousSign(unsignedAtom).getAsTransactionAtom());
 		transactionAtoms.accept(radixIdentity2.synchronousSign(unsignedAtom2).getAsTransactionAtom());
 		assertEquals(1, transactionAtoms.getUnconsumedConsumables().count());


### PR DESCRIPTION
* Expose interface which doesn't depend on address knowing what it's public key is but can check
* Add RadixAddress constructor that is not dependent on a UniverseConfig
* Update TransactionAtomsTest so it's not dependent on a RadixUniverse instance

Solves #3 