### PR TITLE
Modifications to work with RadixCore euid128 change.

### DIFF
--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/address/EUID.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/address/EUID.java
@@ -1,8 +1,11 @@
 package com.radixdlt.client.core.address;
 
 import java.math.BigInteger;
+import java.util.Arrays;
 
-public class EUID {
+public final class EUID {
+	public static final int BYTES = Long.BYTES * 2;
+
 	private final BigInteger value;
 
 	public EUID(byte[] value) {
@@ -28,7 +31,7 @@ public class EUID {
 
 	@Override
 	public boolean equals(Object o) {
-		if (o == null || !(o instanceof EUID)) {
+		if (!(o instanceof EUID)) {
 			return false;
 		}
 
@@ -39,5 +42,26 @@ public class EUID {
 	@Override
 	public String toString() {
 		return value.toString();
+	}
+
+	/**
+	 * Return an array of {@code byte} that represents this {@link EUID}.
+	 * Note that the returned array is always {@link #BYTES} bytes in length,
+	 * and is padded on the right with the value of the sign bit, if necessary.
+	 *
+	 * @return An array of {@link #BYTES} bytes.
+	 */
+	public byte[] toByteArray() {
+		byte[] bytes = value.toByteArray();
+		if (bytes.length < BYTES) {
+			// Pad with sign bit
+			byte[] newBytes = new byte[BYTES];
+			int fillSize = BYTES - bytes.length;
+			byte fill = (bytes[0] < 0) ? (byte)-1 : (byte)0;
+			Arrays.fill(newBytes, 0, fillSize, fill);
+			System.arraycopy(bytes, 0, newBytes, fillSize, bytes.length);
+			return newBytes;
+		}
+		return bytes;
 	}
 }

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/address/EUID.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/address/EUID.java
@@ -57,7 +57,7 @@ public final class EUID {
 			// Pad with sign bit
 			byte[] newBytes = new byte[BYTES];
 			int fillSize = BYTES - bytes.length;
-			byte fill = (bytes[0] < 0) ? (byte)-1 : (byte)0;
+			byte fill = (bytes[0] < 0) ? (byte) -1 : (byte) 0;
 			Arrays.fill(newBytes, 0, fillSize, fill);
 			System.arraycopy(bytes, 0, newBytes, fillSize, bytes.length);
 			return newBytes;

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/RadixHash.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/RadixHash.java
@@ -1,15 +1,15 @@
 package com.radixdlt.client.core.atoms;
 
-import com.radixdlt.client.core.address.EUID;
-import com.radixdlt.client.core.crypto.ECPublicKey;
-import com.radixdlt.client.core.crypto.ECSignature;
-import com.radixdlt.client.core.util.Hash;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
-public class RadixHash {
-	private static final int HASH_MAX_SIZE = 12;
+import com.radixdlt.client.core.address.EUID;
+import com.radixdlt.client.core.crypto.ECPublicKey;
+import com.radixdlt.client.core.crypto.ECSignature;
+import com.radixdlt.client.core.util.Hash;
+
+public final class RadixHash {
 	private final byte[] hash;
 
 	private RadixHash(byte[] hash) {
@@ -21,7 +21,7 @@ public class RadixHash {
 	}
 
 	public EUID toEUID() {
-		return new EUID(Arrays.copyOfRange(hash, 0, HASH_MAX_SIZE));
+		return new EUID(Arrays.copyOfRange(hash, 0, EUID.BYTES));
 	}
 
 	public void putSelf(ByteBuffer byteBuffer) {

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/serialization/Dson.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/serialization/Dson.java
@@ -1,12 +1,5 @@
 package com.radixdlt.client.core.serialization;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.annotations.SerializedName;
-import com.radixdlt.client.core.address.EUID;
-import com.radixdlt.client.core.util.Base64Encoded;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -24,8 +17,17 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import okio.ByteString;
 import org.bouncycastle.util.encoders.Base64;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.annotations.SerializedName;
+import com.radixdlt.client.core.address.EUID;
+import com.radixdlt.client.core.util.Base64Encoded;
+
+import okio.ByteString;
 
 public class Dson {
 	private enum Primitive {
@@ -187,7 +189,7 @@ public class Dson {
 			raw = longToByteArray((Long) o);
 			type = 2;
 		} else if (o instanceof EUID) {
-			raw = ((EUID) o).bigInteger().toByteArray();
+			raw = ((EUID) o).toByteArray();
 			type = 7;
 		} else if (o instanceof Base64Encoded) {
 			raw = ((Base64Encoded) o).toByteArray();

--- a/radixdlt-java/src/test/java/com/radixdlt/client/core/address/RadixAddressTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/core/address/RadixAddressTest.java
@@ -1,12 +1,13 @@
 package com.radixdlt.client.core.address;
 
-import com.radixdlt.client.core.crypto.ECPublicKey;
-import org.bouncycastle.util.encoders.Base64;
-import org.junit.Test;
-
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
+
+import org.bouncycastle.util.encoders.Base64;
+import org.junit.Test;
+
+import com.radixdlt.client.core.crypto.ECPublicKey;
 
 import static org.junit.Assert.assertEquals;
 
@@ -29,7 +30,7 @@ public class RadixAddressTest {
 	@Test
 	public void createAddressAndCheckUID() {
 		RadixAddress address = new RadixAddress("JHB89drvftPj6zVCNjnaijURk8D8AMFw4mVja19aoBGmRXWchnJ");
-		assertEquals(new EUID(new BigInteger("-35592036731042511330623796977")), address.getUID());
+		assertEquals(new EUID(new BigInteger("-152866633757858334150738651292965210305")), address.getUID());
 	}
 
 	@Test


### PR DESCRIPTION
Note that `radixdlt-java/src/main/resources/universe/*.json` have **not** been regenerated.  This will need to happen before this library is deployed.