### PR TITLE
Shard IDs are now the high-order word of EUIDs

### DIFF
--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/address/EUID.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/address/EUID.java
@@ -27,7 +27,7 @@ public final class EUID {
 	}
 
 	public long getShard() {
-		return value.getLow();
+		return value.getHigh();
 	}
 
 	@Override

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/Shards.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/Shards.java
@@ -2,7 +2,7 @@ package com.radixdlt.client.core.atoms;
 
 import java.util.Collection;
 
-public class Shards {
+public final class Shards {
 	private final long low;
 	private final long high;
 
@@ -20,7 +20,11 @@ public class Shards {
 	}
 
 	public boolean intersects(Collection<Long> shards) {
-		return shards.stream().anyMatch(shard -> shard >= low && shard <= high);
+		return shards.stream().anyMatch(this::contains);
+	}
+
+	public boolean contains(long shard) {
+		return shard >= low && shard <= high;
 	}
 
 	@Override
@@ -30,7 +34,7 @@ public class Shards {
 
 	@Override
 	public boolean equals(Object o) {
-		if (o == null || !(o instanceof Shards)) {
+		if (!(o instanceof Shards)) {
 			return false;
 		}
 
@@ -40,7 +44,6 @@ public class Shards {
 
 	@Override
 	public int hashCode() {
-		//TODO: fix HACK
-		return (low + "-" + high).hashCode();
+		return Long.hashCode(high) * 31 + Long.hashCode(low);
 	}
 }


### PR DESCRIPTION
Shard IDs are now the high-order word of EUIDs.
Some minor, largely unrelated tweaks in Shards.java.