### PR TITLE
Gradle: Update Mockito to version 2.17.0

### DIFF
--- a/radixdlt-java/build.gradle
+++ b/radixdlt-java/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.7.22'
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.17.0'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.11.0'
 }
 


### PR DESCRIPTION
This is required to fix an exception caused by Byte Buddy v1.7 in Java 10:

    Caused by:
    org.mockito.exceptions.base.MockitoInitializationException:
    Could not initialize inline Byte Buddy mock maker. (This mock maker is not supported on Android.)

Mockito v2.17.0 and up require Byte Buddy v1.8, which no longer throws the
exception.

Output of 'gradle test' with patch on Java 8, Gradle 3.4.1:

    BUILD SUCCESSFUL

Output of 'gradle test' with patch on Java 10, latest Gradle:

    BUILD SUCCESSFUL in 5m 40s
    7 actionable tasks: 7 executed