### PR TITLE
Add delay in between node connection requests

### DIFF
--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/ledger/ClientSelector.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/ledger/ClientSelector.java
@@ -4,9 +4,11 @@ import com.radixdlt.client.core.address.RadixUniverseConfig;
 import com.radixdlt.client.core.network.RadixJsonRpcClient;
 import com.radixdlt.client.core.network.RadixNetwork;
 import com.radixdlt.client.core.network.WebSocketClient.RadixClientStatus;
+import io.reactivex.Observable;
 import io.reactivex.Single;
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +24,11 @@ public class ClientSelector {
 	private final RadixUniverseConfig config;
 
 	/**
+	 * The amount of time to delay in between node connection requests
+	 */
+	private final int delaySecs;
+
+	/**
 	 * The network of peers available to connect to
 	 */
 	private final RadixNetwork radixNetwork;
@@ -29,6 +36,7 @@ public class ClientSelector {
 	public ClientSelector(RadixUniverseConfig config, RadixNetwork radixNetwork) {
 		this.config = config;
 		this.radixNetwork = radixNetwork;
+		this.delaySecs = 3;
 	}
 
 	/**
@@ -59,6 +67,7 @@ public class ClientSelector {
 					.toMaybe()
 					.onErrorComplete()
 			)
+			.zipWith(Observable.timer(delaySecs, TimeUnit.SECONDS), (c, t) -> c)
 			.flatMapMaybe(client ->
 				client.getUniverse()
 					.doOnSuccess(cliUniverse -> {

--- a/radixdlt-java/src/test/java/com/radixdlt/client/core/ledger/ClientSelectorTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/core/ledger/ClientSelectorTest.java
@@ -2,6 +2,8 @@ package com.radixdlt.client.core.ledger;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.radixdlt.client.core.address.RadixUniverseConfig;
@@ -12,7 +14,11 @@ import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.observers.TestObserver;
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.Test;
 
 public class ClientSelectorTest {
@@ -31,5 +37,32 @@ public class ClientSelectorTest {
 
 		testObserver.assertNoErrors();
 		testObserver.assertNoValues();
+	}
+
+	@Test
+	public void dontConnectToAllNodesTest() {
+		RadixUniverseConfig config = mock(RadixUniverseConfig.class);
+
+		RadixNetwork network = mock(RadixNetwork.class);
+		List<RadixJsonRpcClient> clients = IntStream.range(0, 100).mapToObj(i -> {
+			RadixJsonRpcClient client = mock(RadixJsonRpcClient.class);
+			when(client.getStatus()).thenReturn(Observable.just(RadixClientStatus.CLOSED));
+			if (i == 0) {
+				when(client.getUniverse()).thenReturn(Single.timer(1, TimeUnit.SECONDS).map(t -> config));
+			} else {
+				when(client.getUniverse()).thenReturn(Single.never());
+			}
+			return client;
+		}).collect(Collectors.toList());
+		when(network.getRadixClients(any(Set.class)))
+			.thenReturn(Observable.fromIterable(clients));
+
+		ClientSelector clientSelector = new ClientSelector(config, network);
+		TestObserver<RadixJsonRpcClient> testObserver = TestObserver.create();
+		clientSelector.getRadixClient(1L).subscribe(testObserver);
+		testObserver.awaitTerminalEvent();
+		testObserver.assertValue(clients.get(0));
+
+		verify(clients.get(99), times(0)).getUniverse();
 	}
 }


### PR DESCRIPTION
Removes bug where client is connecting to every single node as it waits for a connection.