### PR TITLE
The DSON/JSON "serializer" field is now included when calculating the hash.

### DIFF
--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/address/RadixUniverseConfig.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/address/RadixUniverseConfig.java
@@ -9,8 +9,8 @@ import java.util.List;
 import org.bouncycastle.util.encoders.Base64;
 import org.radix.serialization2.DsonOutput;
 import org.radix.serialization2.DsonOutput.Output;
-import org.radix.serialization2.SerializerDummy;
 import org.radix.serialization2.SerializerId2;
+import org.radix.serialization2.client.SerializableObject;
 import org.radix.serialization2.client.Serialize;
 import org.radix.utils.RadixConstants;
 
@@ -21,16 +21,7 @@ import com.radixdlt.client.core.atoms.RadixHash;
 import com.radixdlt.client.core.crypto.ECPublicKey;
 
 @SerializerId2("UNIVERSE")
-public class RadixUniverseConfig {
-
-	@JsonProperty("version")
-	@DsonOutput(Output.ALL)
-	private short version = 100;
-
-	// Placeholder for the serializer ID
-	@JsonProperty("serializer")
-	@DsonOutput({Output.API, Output.WIRE, Output.PERSIST})
-	private SerializerDummy serializer = SerializerDummy.DUMMY;
+public class RadixUniverseConfig extends SerializableObject {
 
 	@JsonProperty("magic")
 	@DsonOutput(value = Output.HASH, include = false)

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/AccountReference.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/AccountReference.java
@@ -2,24 +2,15 @@ package com.radixdlt.client.core.atoms;
 
 import org.radix.serialization2.DsonOutput;
 import org.radix.serialization2.DsonOutput.Output;
-import org.radix.serialization2.SerializerDummy;
 import org.radix.serialization2.SerializerId2;
+import org.radix.serialization2.client.SerializableObject;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.radixdlt.client.core.crypto.ECKeyPair;
 import com.radixdlt.client.core.crypto.ECPublicKey;
 
 @SerializerId2("ACCOUNTREFERENCE")
-public class AccountReference {
-	@JsonProperty("version")
-	@DsonOutput(Output.ALL)
-	private short version = 100;
-
-	// Placeholder for the serializer ID
-	@JsonProperty("serializer")
-	@DsonOutput({Output.API, Output.WIRE, Output.PERSIST})
-	private SerializerDummy serializer = SerializerDummy.DUMMY;
-
+public class AccountReference extends SerializableObject {
 	@JsonProperty("key")
 	@DsonOutput(Output.ALL)
 	private ECKeyPair key;

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/Atom.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/Atom.java
@@ -1,19 +1,5 @@
 package com.radixdlt.client.core.atoms;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.radixdlt.client.core.atoms.particles.Particle;
-import com.radixdlt.client.core.atoms.particles.Spin;
-import com.radixdlt.client.core.atoms.particles.StorageParticle;
-import com.radixdlt.client.core.atoms.particles.TimestampParticle;
-import com.radixdlt.client.core.atoms.particles.TransferParticle;
-import com.radixdlt.client.core.crypto.ECPublicKey;
-import com.radixdlt.client.core.crypto.ECSignature;
-import org.radix.common.ID.EUID;
-import org.radix.serialization2.DsonOutput;
-import org.radix.serialization2.SerializerDummy;
-import org.radix.serialization2.SerializerId2;
-import org.radix.serialization2.client.Serialize;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -23,20 +9,27 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.radix.common.ID.EUID;
+import org.radix.serialization2.DsonOutput;
+import org.radix.serialization2.SerializerId2;
+import org.radix.serialization2.client.SerializableObject;
+import org.radix.serialization2.client.Serialize;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.radixdlt.client.core.atoms.particles.Particle;
+import com.radixdlt.client.core.atoms.particles.Spin;
+import com.radixdlt.client.core.atoms.particles.StorageParticle;
+import com.radixdlt.client.core.atoms.particles.TimestampParticle;
+import com.radixdlt.client.core.atoms.particles.TransferParticle;
+import com.radixdlt.client.core.crypto.ECPublicKey;
+import com.radixdlt.client.core.crypto.ECSignature;
+
 /**
  * An atom is the fundamental atomic unit of storage on the ledger (similar to a block
  * in a blockchain) and defines the actions that can be issued onto the ledger.
  */
 @SerializerId2("ATOM")
-public final class Atom {
-	@JsonProperty("version")
-	@DsonOutput(DsonOutput.Output.ALL)
-	private short version = 100;
-
-	// Placeholder for the serializer ID
-	@JsonProperty("serializer")
-	@DsonOutput({DsonOutput.Output.API, DsonOutput.Output.WIRE, DsonOutput.Output.PERSIST})
-	private SerializerDummy serializer = SerializerDummy.DUMMY;
+public final class Atom extends SerializableObject {
 
 	@JsonProperty("particles")
 	@DsonOutput(DsonOutput.Output.ALL)

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/TokenClassReference.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/TokenClassReference.java
@@ -8,13 +8,13 @@ import java.util.Objects;
 import org.radix.common.ID.EUID;
 import org.radix.serialization2.DsonOutput;
 import org.radix.serialization2.DsonOutput.Output;
-import org.radix.serialization2.SerializerDummy;
 import org.radix.serialization2.SerializerId2;
+import org.radix.serialization2.client.SerializableObject;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @SerializerId2("TOKENCLASSREFERENCE")
-public final class TokenClassReference {
+public final class TokenClassReference extends SerializableObject {
 	private static final Charset CHARSET = StandardCharsets.UTF_8;
 
 	private static final int TOKEN_SCALE = 5;
@@ -32,15 +32,6 @@ public final class TokenClassReference {
 	public static BigDecimal subUnitsToDecimal(long subUnits) {
 		return BigDecimal.valueOf(subUnits, TOKEN_SCALE);
 	}
-
-	@JsonProperty("version")
-	@DsonOutput(Output.ALL)
-	private short version = 100;
-
-	// Placeholder for the serializer ID
-	@JsonProperty("serializer")
-	@DsonOutput({Output.API, Output.WIRE, Output.PERSIST})
-	private SerializerDummy serializer = SerializerDummy.DUMMY;
 
 	@JsonProperty("address")
 	@DsonOutput(Output.ALL)

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/particles/Particle.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/particles/Particle.java
@@ -1,12 +1,5 @@
 package com.radixdlt.client.core.atoms.particles;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.radixdlt.client.core.atoms.particles.quarks.Quark;
-import com.radixdlt.client.core.crypto.ECPublicKey;
-import org.radix.serialization2.DsonOutput;
-import org.radix.serialization2.SerializerDummy;
-import org.radix.serialization2.SerializerId2;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -16,25 +9,24 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import org.radix.serialization2.DsonOutput;
+import org.radix.serialization2.SerializerId2;
+import org.radix.serialization2.client.SerializableObject;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.radixdlt.client.core.atoms.particles.quarks.Quark;
+import com.radixdlt.client.core.crypto.ECPublicKey;
+
 /**
  * A logical action on the ledger, composed of distinct {@link Quark} properties
  */
 @SerializerId2("PARTICLE")
-public abstract class Particle {
+public abstract class Particle extends SerializableObject {
 	private Spin spin;
-
-	@JsonProperty("version")
-	@DsonOutput(DsonOutput.Output.ALL)
-	private short version = 100;
 
 	@JsonProperty("quarks")
 	@DsonOutput(DsonOutput.Output.ALL)
 	private final List<Quark> quarks; // immutable for now, later on will be able to modify after construction
-
-	// Placeholder for the serializer ID
-	@JsonProperty("serializer")
-	@DsonOutput({DsonOutput.Output.API, DsonOutput.Output.WIRE, DsonOutput.Output.PERSIST})
-	private SerializerDummy serializer = SerializerDummy.DUMMY;
 
 	protected Particle() {
 		this.quarks = Collections.emptyList();

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/particles/quarks/Quark.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/particles/quarks/Quark.java
@@ -1,19 +1,9 @@
 package com.radixdlt.client.core.atoms.particles.quarks;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.radix.serialization2.DsonOutput;
-import org.radix.serialization2.SerializerDummy;
+import org.radix.serialization2.client.SerializableObject;
 
 /**
  * A distinct property of a {@link com.radixdlt.client.core.atoms.particles.Particle}
  */
-public abstract class Quark {
-	@JsonProperty("version")
-	@DsonOutput(DsonOutput.Output.ALL)
-	private short version = 100;
-
-	// Placeholder for the serializer ID
-	@JsonProperty("serializer")
-	@DsonOutput({DsonOutput.Output.API, DsonOutput.Output.WIRE, DsonOutput.Output.PERSIST})
-	private SerializerDummy serializer = SerializerDummy.DUMMY;
+public abstract class Quark extends SerializableObject {
 }

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/crypto/ECKeyPair.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/crypto/ECKeyPair.java
@@ -21,24 +21,15 @@ import org.bouncycastle.math.ec.ECPoint;
 import org.radix.common.ID.EUID;
 import org.radix.serialization2.DsonOutput;
 import org.radix.serialization2.DsonOutput.Output;
-import org.radix.serialization2.SerializerDummy;
 import org.radix.serialization2.SerializerId2;
+import org.radix.serialization2.client.SerializableObject;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.radixdlt.client.core.atoms.RadixHash;
 
 
 @SerializerId2("ECKEYPAIR")
-public class ECKeyPair {
-	@JsonProperty("version")
-	@DsonOutput(Output.ALL)
-	private short version = 100;
-
-	// Placeholder for the serializer ID
-	@JsonProperty("serializer")
-	@DsonOutput({Output.API, Output.WIRE, Output.PERSIST})
-	private SerializerDummy serializer = SerializerDummy.DUMMY;
-
+public class ECKeyPair extends SerializableObject {
 	@JsonProperty("public")
 	@DsonOutput(Output.ALL)
 	private ECPublicKey publicKey;

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/crypto/ECSignature.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/crypto/ECSignature.java
@@ -5,22 +5,13 @@ import java.math.BigInteger;
 import org.bouncycastle.util.encoders.Base64;
 import org.radix.serialization2.DsonOutput;
 import org.radix.serialization2.DsonOutput.Output;
-import org.radix.serialization2.SerializerDummy;
 import org.radix.serialization2.SerializerId2;
+import org.radix.serialization2.client.SerializableObject;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @SerializerId2("SIGNATURE")
-public class ECSignature {
-	@JsonProperty("version")
-	@DsonOutput(Output.ALL)
-	private short version = 100;
-
-	// Placeholder for the serializer ID
-	@JsonProperty("serializer")
-	@DsonOutput({Output.API, Output.WIRE, Output.PERSIST})
-	private SerializerDummy serializer = SerializerDummy.DUMMY;
-
+public class ECSignature extends SerializableObject {
 	private byte[] r;
 	private byte[] s;
 

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/network/NodeRunnerData.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/network/NodeRunnerData.java
@@ -4,22 +4,13 @@ import java.util.Map;
 
 import org.radix.serialization2.DsonOutput;
 import org.radix.serialization2.DsonOutput.Output;
-import org.radix.serialization2.SerializerDummy;
+import org.radix.serialization2.client.SerializableObject;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import com.radixdlt.client.core.atoms.Shards;
 
-public abstract class NodeRunnerData {
-	@JsonProperty("version")
-	@DsonOutput(Output.ALL)
-	private short version = 100;
-
-	// Placeholder for the serializer ID
-	@JsonProperty("serializer")
-	@DsonOutput({Output.API, Output.WIRE, Output.PERSIST})
-	private SerializerDummy serializer = SerializerDummy.DUMMY;
-
+public abstract class NodeRunnerData extends SerializableObject {
 	private String ip;
 
 	@JsonProperty("system")

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/network/RadixSystem.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/network/RadixSystem.java
@@ -4,8 +4,8 @@ import java.util.Map;
 
 import org.radix.serialization2.DsonOutput;
 import org.radix.serialization2.DsonOutput.Output;
-import org.radix.serialization2.SerializerDummy;
 import org.radix.serialization2.SerializerId2;
+import org.radix.serialization2.client.SerializableObject;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.radixdlt.client.core.atoms.Shards;
@@ -13,16 +13,7 @@ import com.radixdlt.client.core.atoms.Shards;
 import static org.radix.serialization2.MapHelper.mapOf;
 
 @SerializerId2("SYSTEM")
-public class RadixSystem {
-	@JsonProperty("version")
-	@DsonOutput(Output.ALL)
-	private short version = 100;
-
-	// Placeholder for the serializer ID
-	@JsonProperty("serializer")
-	@DsonOutput({Output.API, Output.WIRE, Output.PERSIST})
-	private SerializerDummy serializer = SerializerDummy.DUMMY;
-
+public class RadixSystem extends SerializableObject {
 	private Shards shards;
 
 	RadixSystem() {

--- a/radixdlt-java/src/main/java/org/radix/serialization2/MapHelper.java
+++ b/radixdlt-java/src/main/java/org/radix/serialization2/MapHelper.java
@@ -146,14 +146,42 @@ public final class MapHelper {
 	 * @param v5 The value of the fifth  element to add to the new map
 	 * @param k6 The key of the sixth element to add to the new map
 	 * @param v6 The value of the sixth  element to add to the new map
-	 * @param k7 The key of the sixth element to add to the new map
-	 * @param v7 The value of the sixth  element to add to the new map
+	 * @param k7 The key of the seventh element to add to the new map
+	 * @param v7 The value of the seventh  element to add to the new map
 	 * @return A freshly created mutable map with the specified contents
 	 */
 	public static Map<String, Object> mapOf(String k1, Object v1, String k2, Object v2, String k3, Object v3, String k4, Object v4,
 			String k5, Object v5, String k6, Object v6, String k7, Object v7) {
 		Map<String, Object> newMap = mapOf(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6);
 		newMap.put(k7, v7);
+		return newMap;
+	}
+
+	/**
+	 * Create a new mutable map with the specified contents.
+	 *
+	 * @param k1 The key of the first element to add to the new map
+	 * @param v1 The value of the first element to add to the new map
+	 * @param k2 The key of the second element to add to the new map
+	 * @param v2 The value of the second element to add to the new map
+	 * @param k3 The key of the third element to add to the new map
+	 * @param v3 The value of the third element to add to the new map
+	 * @param k4 The key of the fourth element to add to the new map
+	 * @param v4 The value of the fourth element to add to the new map
+	 * @param k5 The key of the fifth element to add to the new map
+	 * @param v5 The value of the fifth  element to add to the new map
+	 * @param k6 The key of the sixth element to add to the new map
+	 * @param v6 The value of the sixth  element to add to the new map
+	 * @param k7 The key of the seventh element to add to the new map
+	 * @param v7 The value of the seventh element to add to the new map
+	 * @param k8 The key of the eighth element to add to the new map
+	 * @param v8 The value of the eighth element to add to the new map
+	 * @return A freshly created mutable map with the specified contents
+	 */
+	public static Map<String, Object> mapOf(String k1, Object v1, String k2, Object v2, String k3, Object v3, String k4, Object v4,
+			String k5, Object v5, String k6, Object v6, String k7, Object v7, String k8, Object v8) {
+		Map<String, Object> newMap = mapOf(k1, v1, k2, v2, k3, v3, k4, v4, k5, v5, k6, v6, k7, v7);
+		newMap.put(k8, v8);
 		return newMap;
 	}
 }

--- a/radixdlt-java/src/main/java/org/radix/serialization2/SerializerConstants.java
+++ b/radixdlt-java/src/main/java/org/radix/serialization2/SerializerConstants.java
@@ -10,4 +10,7 @@ public final class SerializerConstants {
 
 	// At least this will cause compilation fail when updated
 	public static final Class<SerializerId2> SERIALIZER_ID_ANNOTATION = SerializerId2.class;
+
+	// The serialized type field name
+	public static final String SERIALIZER_NAME = "serializer";
 }

--- a/radixdlt-java/src/main/java/org/radix/serialization2/client/SerializableObject.java
+++ b/radixdlt-java/src/main/java/org/radix/serialization2/client/SerializableObject.java
@@ -1,0 +1,23 @@
+package org.radix.serialization2.client;
+
+import org.radix.serialization2.DsonOutput;
+import org.radix.serialization2.DsonOutput.Output;
+import org.radix.serialization2.SerializerDummy;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Class with serializable fields for version and serializer
+ * that can be inherited to easily implement those fields in
+ * a standard way for DSON and JSON output.
+ */
+public class SerializableObject {
+	@JsonProperty("version")
+	@DsonOutput(Output.ALL)
+	private short version = 100;
+
+	// Placeholder for the serializer ID
+	@JsonProperty("serializer")
+	@DsonOutput(Output.ALL)
+	private SerializerDummy serializer = SerializerDummy.DUMMY;
+}

--- a/radixdlt-java/src/main/java/org/radix/serialization2/client/SerializableObject.java
+++ b/radixdlt-java/src/main/java/org/radix/serialization2/client/SerializableObject.java
@@ -2,6 +2,7 @@ package org.radix.serialization2.client;
 
 import org.radix.serialization2.DsonOutput;
 import org.radix.serialization2.DsonOutput.Output;
+import org.radix.serialization2.SerializerConstants;
 import org.radix.serialization2.SerializerDummy;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -17,7 +18,7 @@ public class SerializableObject {
 	private short version = 100;
 
 	// Placeholder for the serializer ID
-	@JsonProperty("serializer")
+	@JsonProperty(SerializerConstants.SERIALIZER_NAME)
 	@DsonOutput(Output.ALL)
 	private SerializerDummy serializer = SerializerDummy.DUMMY;
 }

--- a/radixdlt-java/src/main/java/org/radix/serialization2/mapper/DsonTypeResolverBuilder.java
+++ b/radixdlt-java/src/main/java/org/radix/serialization2/mapper/DsonTypeResolverBuilder.java
@@ -2,6 +2,7 @@ package org.radix.serialization2.mapper;
 
 import java.util.Collection;
 
+import org.radix.serialization2.SerializerConstants;
 import org.radix.serialization2.SerializerIds;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
@@ -29,7 +30,7 @@ class DsonTypeResolverBuilder extends ObjectMapper.DefaultTypeResolverBuilder {
 
 	DsonTypeResolverBuilder(SerializerIds idLookup) {
 		super(ObjectMapper.DefaultTyping.NON_FINAL);
-		init(Id.CUSTOM, null).inclusion(As.EXISTING_PROPERTY).typeProperty("serializer");
+		init(Id.CUSTOM, null).inclusion(As.EXISTING_PROPERTY).typeProperty(SerializerConstants.SERIALIZER_NAME);
 		this.idLookup = idLookup;
 	}
 
@@ -50,8 +51,8 @@ class DsonTypeResolverBuilder extends ObjectMapper.DefaultTypeResolverBuilder {
 	}
 
     @Override
-	protected TypeIdResolver idResolver(MapperConfig<?> config, JavaType baseType,
-			Collection<NamedType> subtypes, boolean forSer, boolean forDeser) {
+	protected TypeIdResolver idResolver(MapperConfig<?> config, JavaType baseType, Collection<NamedType> subtypes,
+			boolean forSer, boolean forDeser) {
 		return new DsonTypeIdResolver(baseType, config.getTypeFactory(), idLookup);
 	}
 }

--- a/radixdlt-java/src/main/java/org/radix/serialization2/mapper/MapperConstants.java
+++ b/radixdlt-java/src/main/java/org/radix/serialization2/mapper/MapperConstants.java
@@ -1,15 +1,9 @@
 package org.radix.serialization2.mapper;
 
-import org.radix.common.tuples.Pair;
-import org.radix.serialization2.SerializerDummy;
-
 final class MapperConstants {
 	private MapperConstants() {
 		throw new IllegalStateException("Can't construct");
 	}
-
-	static final String SERIALIZER_FIELD_NAME = "serializer";
-	static final Pair<Class<?>, String> SERIALIZER_FIELD = Pair.of(SerializerDummy.class, SERIALIZER_FIELD_NAME);
 
 	static final String DSON_FILTER_NAME = "DSON";
 }

--- a/radixdlt-java/src/main/resources/universe/betanet.json
+++ b/radixdlt-java/src/main/resources/universe/betanet.json
@@ -1,8 +1,8 @@
 {
     "magic": 63799298,
     "creator": ":byt:A3hanCWf3pmR5E+i+wtWWfKleBrDOQduLb/vcFKOSt9o",
-    "signature.r": ":byt:AOTlWWHSWMy8Wq1OVOki+7Y0AkOQ5n+haItOJvRjklff",
-    "signature.s": ":byt:AIC7nOt5D502OEVDAZ0koUfy9T4nWIdbCjZsbJXsfbgO",
+    "signature.r": ":byt:AIskSMwKE0QXBFTFTZxhlB17ptQ5OAdwy1QFct9QFFbC",
+    "signature.s": ":byt:AM6bqrZs80PhByoWO6S2/jKG6ND5/kWX8RKVcu2yvTdZ",
     "serializer": 492321349,
     "description": ":str:The Radix development Universe",
     "type": 2,
@@ -23,7 +23,7 @@
                     "version": 100,
                     "quarks": [
                         {
-                            "uid": ":uid:b92a9a7f113b4f111bed8ec6644ebf4f",
+                            "uid": ":uid:93c845be0c2cb269bbd8c1dddba08d4c",
                             "serializer": 1759354159,
                             "version": 100
                         },
@@ -77,8 +77,8 @@
             ],
             "version": 100,
             "signatures": {"56abab3870585f04d015d55adf600bc7": {
-                "r": ":byt:MGhUpXU7YnagNYBQ2iLdH0kLhOwLC1uiyIupkkdJPvA=",
-                "s": ":byt:AOANMd8uvloxy72Xx9XjSveEOpHPBhmxO1SyztFlVvSP",
+                "r": ":byt:APX/4b7f9W4cPgPxSA/iSGAmCWHY0Kn4VgoSRBSZtkdW",
+                "s": ":byt:AM6OWhDsbTezfCv+s7OIIqdWMt+mij6cqciy3ikTd/6W",
                 "serializer": -434788200,
                 "version": 100
             }}
@@ -97,7 +97,7 @@
                     "version": 100,
                     "quarks": [
                         {
-                            "uid": ":uid:76e7b1c70815474c3dfd4d612ede639b",
+                            "uid": ":uid:c1f319e073bbc64b8265fa9b37d8e3f3",
                             "serializer": 1759354159,
                             "version": 100
                         },
@@ -151,29 +151,29 @@
             ],
             "version": 100,
             "signatures": {"56abab3870585f04d015d55adf600bc7": {
-                "r": ":byt:ALIqGeGIGKHD9qSDRmRuAClmmA/r1afnUQB+XpMC4nQU",
-                "s": ":byt:AMeu/DLui91DN6NrA7BLsmOrPg8zF3xU5pLJFXU1tQ1u",
+                "r": ":byt:ALlirAdvbOOa5woOUSKotk9TXd9D5xuqc1dkdlMaafWX",
+                "s": ":byt:ALzwrSUXFdElW8uzjOIheqvsQqiQS0LeuoeFZwy1mUkC",
                 "serializer": -434788200,
                 "version": 100
             }}
         },
         {
             "temporal_proof": {
-                "atom_id": ":uid:691e3a11031ae4c87cbbbf145e7dbd85",
+                "atom_id": ":uid:79eab53f513e6dacf8cb396cc0b376b4",
                 "vertices": [{
                     "owner": {
-                        "public": ":byt:AwXD1q1wqvyc7Sj6o8QF6dS2MPphe5p6FD8makW5kkUx",
+                        "public": ":byt:AiDi9s7Y2EOIS7Jt7WJ09KempPMII3hb3HeBV/MaA/qm",
                         "serializer": 547221307,
                         "version": 100
                     },
                     "previous": ":uid:00000000000000000000000000000000",
                     "signature": {
-                        "r": ":byt:Rd6amfCaBzMTD2rSGTTo31XT6ZUkC1bQ7IRP6b6vcjQ=",
-                        "s": ":byt:ALn6UxgFNV3AX39jWRSgWRSkI2nYGsZ7gb79f1UxRfB8",
+                        "r": ":byt:JfTX9083zIHfUC0UOGt44OHEnHnF/KZBTSxljThIqh8=",
+                        "s": ":byt:ALdNRDuGAQGTo66IH/E2gzNFvBVJH5/GsOtxWEl6nvTH",
                         "serializer": -434788200,
                         "version": 100
                     },
-                    "timestamps": {"default": 1539978773207},
+                    "timestamps": {"default": 1540293816839},
                     "serializer": -909337786,
                     "commitment": ":hsh:0000000000000000000000000000000000000000000000000000000000000000",
                     "clock": 0,
@@ -270,7 +270,7 @@
                             "serializer": 572705468,
                             "type": ":str:minted",
                             "version": 100,
-                            "nonce": 387815151865891,
+                            "nonce": 222342013419864,
                             "planck": 24805440
                         }
                     ]
@@ -278,8 +278,8 @@
             ],
             "version": 100,
             "signatures": {"56abab3870585f04d015d55adf600bc7": {
-                "r": ":byt:AOzSMtMWuzGKs5Dl15YufyF9rJMzQyPv0sRYx6pcbC17",
-                "s": ":byt:ANDgn8wW/z8N9hS3VfRRwtK2ZY9kZd/q6HrHwHrBv9pK",
+                "r": ":byt:AIqbKTPfQVCa41Zl3JhkZ5avjDOtC9f7DetthiwpxAQA",
+                "s": ":byt:ALiI47HUO5rchiimUE6V8118Xf/7fFadNy2msw641mCe",
                 "serializer": -434788200,
                 "version": 100
             }}


### PR DESCRIPTION
Refactored "version" and "serializer" required fields to be in a common base `SerializableObject` class.

Adjusted outputs for "serializer" field to always be included.