### PR TITLE
Replace JUnit4 with JUnit5

### DIFF
--- a/.checkstyle_test.xml
+++ b/.checkstyle_test.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+
+<!--
+
+  Checkstyle configuration that checks the sun coding conventions from:
+
+    - the Java Language Specification at
+      http://java.sun.com/docs/books/jls/second_edition/html/index.html
+
+    - the Sun Code Conventions at http://java.sun.com/docs/codeconv/
+
+    - the Javadoc guidelines at
+      http://java.sun.com/j2se/javadoc/writingdoccomments/index.html
+
+    - the JDK Api documentation http://java.sun.com/j2se/docs/api/index.html
+
+    - some best practices
+
+  Checkstyle is very configurable. Be sure to read the documentation at
+  http://checkstyle.sf.net (or in your downloaded distribution).
+
+  Most Checks are configurable, be sure to consult the documentation.
+
+  To completely disable a check, just comment it out or delete it from the file.
+
+  Finally, it is worth reading the documentation.
+
+-->
+
+<module name="Checker">
+    <!--
+        If you set the basedir property below, then all reported file
+        names will be relative to the specified directory. See
+        http://checkstyle.sourceforge.net/5.x/config.html#Checker
+
+        <property name="basedir" value="${basedir}"/>
+    -->
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+
+    <!-- Checks that a package-info.java file exists for each package.     -->
+    <!-- See http://checkstyle.sf.net/config_javadoc.html#JavadocPackage -->
+    <!-- module name="JavadocPackage"/ -->
+
+    <!-- Checks whether files end with a new line.                        -->
+    <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
+    <!-- module name="NewlineAtEndOfFile"/ -->
+
+    <!-- Checks that property files contain the same keys.         -->
+    <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->
+    <module name="Translation"/>
+
+    <!-- Checks for Size Violations.                    -->
+    <!-- See http://checkstyle.sf.net/config_sizes.html -->
+    <module name="FileLength"/>
+
+    <!-- Checks for whitespace                               -->
+    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+    <!-- module name="FileTabCharacter"/ -->
+
+    <!-- Miscellaneous other checks.                   -->
+    <!-- See http://checkstyle.sf.net/config_misc.html -->
+    <module name="RegexpSingleline">
+        <property name="format" value="\s+$"/>
+        <property name="minimum" value="0"/>
+        <property name="maximum" value="0"/>
+        <property name="message" value="Line has trailing spaces."/>
+    </module>
+
+    <!-- Checks for Headers                                -->
+    <!-- See http://checkstyle.sf.net/config_header.html   -->
+    <!-- <module name="Header"> -->
+    <!--   <property name="headerFile" value="${checkstyle.header.file}"/> -->
+    <!--   <property name="fileExtensions" value="java"/> -->
+    <!-- </module> -->
+
+    <module name="TreeWalker">
+
+        <!-- Checks for Javadoc comments.                     -->
+        <!-- See http://checkstyle.sf.net/config_javadoc.html -->
+        <!-- module name="JavadocMethod"/ -->
+        <!-- module name="JavadocType"/ -->
+        <!-- module name="JavadocVariable"/ -->
+        <!-- module name="JavadocStyle"/ -->
+
+        <!-- Checks for Naming Conventions.                  -->
+        <!-- See http://checkstyle.sf.net/config_naming.html -->
+        <module name="ConstantName"/>
+        <module name="LocalFinalVariableName"/>
+        <module name="LocalVariableName"/>
+        <module name="MemberName"/>
+        <module name="MethodName">
+            <!-- This is the Google Checkstyle configuration, which is a bit
+                 more liberal on method names. Snake case is allowed, e.g. -->
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
+            <message key="name.invalidPattern"
+                     value="Method name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="PackageName"/>
+        <module name="ParameterName"/>
+        <module name="StaticVariableName"/>
+        <module name="TypeName"/>
+
+        <!-- Checks for imports                              -->
+        <!-- See http://checkstyle.sf.net/config_import.html -->
+        <module name="AvoidStarImport"/>
+        <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+        <module name="RedundantImport"/>
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="false"/>
+        </module>
+
+        <!-- Checks for Size Violations.                    -->
+        <!-- See http://checkstyle.sf.net/config_sizes.html -->
+        <module name="LineLength">
+            <property name="max" value="150"/>
+            <property name="ignorePattern" value="^*BQAA.*$"/>
+        </module>
+        <module name="MethodLength"/>
+        <!-- module name="ParameterNumber"/ -->
+
+        <!-- Checks for whitespace                               -->
+        <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+        <module name="EmptyForIteratorPad"/>
+        <module name="GenericWhitespace"/>
+        <module name="MethodParamPad"/>
+        <module name="NoWhitespaceAfter"/>
+        <module name="NoWhitespaceBefore"/>
+        <module name="OperatorWrap"/>
+        <module name="ParenPad"/>
+        <module name="TypecastParenPad"/>
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround"/>
+
+        <!-- Modifier Checks                                    -->
+        <!-- See http://checkstyle.sf.net/config_modifiers.html -->
+        <module name="ModifierOrder"/>
+        <module name="RedundantModifier"/>
+
+        <!-- Checks for blocks. You know, those {}'s         -->
+        <!-- See http://checkstyle.sf.net/config_blocks.html -->
+        <module name="AvoidNestedBlocks"/>
+        <module name="EmptyBlock"/>
+        <module name="LeftCurly"/>
+        <module name="NeedBraces"/>
+        <module name="RightCurly"/>
+
+        <!-- Checks for common coding problems               -->
+        <!-- See http://checkstyle.sf.net/config_coding.html -->
+        <!-- module name="AvoidInlineConditionals"/ -->
+        <module name="EmptyStatement"/>
+        <module name="EqualsHashCode"/>
+        <!-- module name="HiddenField"/ -->
+        <module name="IllegalInstantiation"/>
+        <module name="InnerAssignment"/>
+        <!-- module name="MagicNumber"/ -->
+        <module name="MissingSwitchDefault"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+
+        <!-- Checks for class design                         -->
+        <!-- See http://checkstyle.sf.net/config_design.html -->
+        <!-- module name="DesignForExtension"/ -->
+        <!-- module name="FinalClass"/ -->
+        <module name="HideUtilityClassConstructor"/>
+        <module name="InterfaceIsType"/>
+        <module name="VisibilityModifier"/>
+
+        <!-- Miscellaneous other checks.                   -->
+        <!-- See http://checkstyle.sf.net/config_misc.html -->
+        <module name="ArrayTypeStyle"/>
+        <!-- module name="FinalParameters"/ -->
+        <!-- module name="TodoComment"/ -->
+        <module name="UpperEll"/>
+
+    </module>
+
+</module>

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .gradle
-.idea
 .DS_Store
 .project
 .settings/
@@ -8,3 +7,7 @@ out/
 *.key
 build/
 bin/
+
+# IntelliJ project files
+.idea
+*.iml

--- a/radixdlt-java/build.gradle
+++ b/radixdlt-java/build.gradle
@@ -40,10 +40,16 @@ dependencies {
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.11.0'
 }
 
+// TODO: Consider moving to Google Checkstyle format
+// TODO: https://github.com/checkstyle/checkstyle/tree/master/src/main/resources
 checkstyle {
     configFile rootProject.file('.checkstyle.xml')
     toolVersion '8.10.1'
     showViolations = true
+}
+
+checkstyleTest {
+    configFile rootProject.file('.checkstyle_test.xml')
 }
 
 jar {

--- a/radixdlt-java/build.gradle
+++ b/radixdlt-java/build.gradle
@@ -35,7 +35,10 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
 
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile 'org.junit.vintage:junit-vintage-engine:5.3.2'
+    testCompile 'org.junit.jupiter:junit-jupiter-api:5.3.2'
+    testCompile 'org.junit.jupiter:junit-jupiter-params:5.3.2'
+    testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.3.2'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.17.0'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.11.0'
 }

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/crypto/ECKeyPair.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/crypto/ECKeyPair.java
@@ -19,7 +19,6 @@ import org.bouncycastle.jce.spec.ECPrivateKeySpec;
 import org.bouncycastle.jce.spec.ECPublicKeySpec;
 import org.bouncycastle.math.ec.ECPoint;
 import org.radix.common.ID.EUID;
-import org.radix.crypto.Hash;
 import org.radix.serialization2.DsonOutput;
 import org.radix.serialization2.DsonOutput.Output;
 import org.radix.serialization2.SerializerId2;

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/crypto/ECKeyPair.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/crypto/ECKeyPair.java
@@ -31,50 +31,6 @@ import com.radixdlt.client.core.atoms.RadixHash;
 
 @SerializerId2("ECKEYPAIR")
 public class ECKeyPair extends SerializableObject {
-
-    /**
-     * FIXME: This method doesn't belong here as it doesn't generate a key pair
-     * FIXME: from an elliptic curve, but rather from a SHA-256 hash.
-     * <p>
-     * Generates a new, deterministic {@code ECKeyPair} instance based on the
-     * provided seed.
-     *
-     * @param seed The seed to use when deriving the key pair instance.
-     * @return A key pair that corresponds to the provided seed.
-     * @throws IllegalArgumentException if the seed is empty or a null pointer.
-     */
-    public static ECKeyPair fromSeed(byte[] seed) {
-        if (seed == null) {
-            throw new IllegalArgumentException("Seed must not be null");
-        }
-
-        if (seed.length == 0) {
-            throw new IllegalArgumentException("Seed must not be empty");
-        }
-
-
-        byte[] privateKey = Hash.hash("SHA-256", seed);
-
-        if (privateKey.length != 32) {
-            byte[] copy = new byte[32];
-
-            if (privateKey.length > 32) {
-                // Cut (note that this will limit the key space to something
-                // smaller than what initially may have been intended).
-                copy = Arrays.copyOfRange(privateKey, privateKey.length - 32, privateKey.length);
-            } else {
-                // Pad (note that this will enable a key space smaller than
-                // the full size of the ECKeyPair space).
-                System.arraycopy(privateKey, 0, copy, 32 - privateKey.length, privateKey.length);
-            }
-
-            privateKey = copy;
-        }
-
-        return new ECKeyPair(privateKey);
-    }
-
-
     @JsonProperty("public")
 	@DsonOutput(Output.ALL)
 	private ECPublicKey publicKey;

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/crypto/ECKeyPairGenerator.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/crypto/ECKeyPairGenerator.java
@@ -5,10 +5,13 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
+import java.security.Provider;
 import java.security.SecureRandom;
 import java.security.Security;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -28,18 +31,40 @@ public final class ECKeyPairGenerator {
         install();
     }
 
+    /**
+     * Ensures the proper version of BouncyCastle is installed in the Java Security
+     * repository and that correct secpXYZk1 elliptic curves can be derived.
+     */
     static void install() {
-        if (AndroidUtil.isAndroidRuntime()) {
-            Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
+        Provider requiredBouncyCastleProvider = new BouncyCastleProvider();
+        Provider currentBouncyCastleProvider = Security.getProvider(BouncyCastleProvider.PROVIDER_NAME);
+
+        // Check if the currently installed version of BouncyCastle is the version
+        // we want. NOTE! That Android has a stripped down version of BouncyCastle
+        // by default.
+        if (currentBouncyCastleProvider == null ||
+                currentBouncyCastleProvider.getVersion() !=
+                        requiredBouncyCastleProvider.getVersion()) {
+
+            if (AndroidUtil.isAndroidRuntime()) {
+                Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
+            }
+
+            Security.insertProviderAt(requiredBouncyCastleProvider, 1);
         }
-        Security.insertProviderAt(new BouncyCastleProvider(), 1);
-        DOMAINS.putAll(Stream.of(256)
-                .collect(Collectors.toMap(Integer::new, (bits) -> {
-                    final X9ECParameters curve = bits == 256
-                            ? CustomNamedCurves.getByName("secp" + bits + "k1")
-                            : SECNamedCurves.getByName("secp" + bits + "k1");
-                    return new ECDomainParameters(curve.getCurve(), curve.getG(), curve.getN(), curve.getH());
-                })));
+
+        // Make sure the corresponding custom elliptic curves are exposed as well.
+        List<Integer> bitSpaces = Collections.singletonList(256);
+        if (!DOMAINS.keySet().containsAll(bitSpaces)) {
+            DOMAINS.putAll(bitSpaces
+                    .stream()
+                    .collect(Collectors.toMap(Integer::new, (bits) -> {
+                        final X9ECParameters curve = bits == 256
+                                ? CustomNamedCurves.getByName("secp" + bits + "k1")
+                                : SECNamedCurves.getByName("secp" + bits + "k1");
+                        return new ECDomainParameters(curve.getCurve(), curve.getG(), curve.getN(), curve.getH());
+                    })));
+        }
     }
 
 	public static ECDomainParameters getDomain(int numBits) {

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/crypto/ECKeyPairGenerator.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/crypto/ECKeyPairGenerator.java
@@ -19,6 +19,7 @@ import org.bouncycastle.crypto.ec.CustomNamedCurves;
 import org.bouncycastle.crypto.params.ECDomainParameters;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.jce.spec.ECParameterSpec;
+import org.radix.crypto.Hash;
 
 public final class ECKeyPairGenerator {
 	private static final Map<Integer, ECDomainParameters> DOMAINS;
@@ -91,5 +92,44 @@ public final class ECKeyPairGenerator {
 			throw new RuntimeException(e.getMessage());
 		}
 	}
+
+    /**
+     * Generates a new, deterministic {@code ECKeyPair} instance based on the
+     * provided seed.
+     *
+     * @param seed The seed to use when deriving the key pair instance.
+     * @return A key pair that corresponds to the provided seed.
+     * @throws IllegalArgumentException if the seed is empty or a null pointer.
+     */
+    public ECKeyPair generateKeyPairFromSeed(byte[] seed) {
+        if (seed == null) {
+            throw new IllegalArgumentException("Seed must not be null");
+        }
+
+        if (seed.length == 0) {
+            throw new IllegalArgumentException("Seed must not be empty");
+        }
+
+
+        byte[] privateKey = Hash.hash("SHA-256", seed);
+
+        if (privateKey.length != 32) {
+            byte[] copy = new byte[32];
+
+            if (privateKey.length > 32) {
+                // Cut (note that this will limit the key space to something
+                // smaller than what initially may have been intended).
+                copy = Arrays.copyOfRange(privateKey, privateKey.length - 32, privateKey.length);
+            } else {
+                // Pad (note that this will enable a key space smaller than
+                // the full size of the ECKeyPair space).
+                System.arraycopy(privateKey, 0, copy, 32 - privateKey.length, privateKey.length);
+            }
+
+            privateKey = copy;
+        }
+
+        return new ECKeyPair(privateKey);
+    }
 
 }

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/crypto/ECKeyPairGenerator.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/crypto/ECKeyPairGenerator.java
@@ -20,7 +20,6 @@ import org.bouncycastle.crypto.ec.CustomNamedCurves;
 import org.bouncycastle.crypto.params.ECDomainParameters;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.jce.spec.ECParameterSpec;
-import org.radix.crypto.Hash;
 
 public final class ECKeyPairGenerator {
     private static final Map<Integer, ECDomainParameters> DOMAINS = new HashMap<>();
@@ -36,9 +35,9 @@ public final class ECKeyPairGenerator {
         Security.insertProviderAt(new BouncyCastleProvider(), 1);
         DOMAINS.putAll(Stream.of(256)
                 .collect(Collectors.toMap(Integer::new, (bits) -> {
-                    final X9ECParameters curve = bits == 256 ?
-                            CustomNamedCurves.getByName("secp" + bits + "k1") :
-                            SECNamedCurves.getByName("secp" + bits + "k1");
+                    final X9ECParameters curve = bits == 256
+                            ? CustomNamedCurves.getByName("secp" + bits + "k1")
+                            : SECNamedCurves.getByName("secp" + bits + "k1");
                     return new ECDomainParameters(curve.getCurve(), curve.getG(), curve.getN(), curve.getH());
                 })));
     }

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/crypto/RadixECKeyPairs.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/crypto/RadixECKeyPairs.java
@@ -1,0 +1,63 @@
+package com.radixdlt.client.core.crypto;
+
+import org.radix.crypto.Hash;
+
+import java.util.Arrays;
+
+public class RadixECKeyPairs {
+
+    static {
+        // Make sure the BouncyCastle cryptographic implementation is properly
+        // installed.
+        ECKeyPairGenerator.install();
+    }
+
+    public static RadixECKeyPairs newInstance() {
+        return new RadixECKeyPairs();
+    }
+
+
+    // Intentionally hidden constructor
+    private RadixECKeyPairs() {
+    }
+
+    /**
+     * Generates a new, deterministic {@code ECKeyPair} instance based on the
+     * provided seed.
+     *
+     * @param seed The seed to use when deriving the key pair instance.
+     * @return A key pair that corresponds to the provided seed.
+     * @throws IllegalArgumentException if the seed is empty or a null pointer.
+     */
+    public ECKeyPair generateKeyPairFromSeed(byte[] seed) {
+        if (seed == null) {
+            throw new IllegalArgumentException("Seed must not be null");
+        }
+
+        if (seed.length == 0) {
+            throw new IllegalArgumentException("Seed must not be empty");
+        }
+
+
+        byte[] privateKey = Hash.hash("SHA-256", seed);
+
+        if (privateKey.length != 32) {
+            byte[] copy = new byte[32];
+
+            if (privateKey.length > 32) {
+                // Cut (note that this will limit the key space to something
+                // smaller than what initially may have been intended).
+                copy = Arrays.copyOfRange(privateKey, privateKey.length - 32, privateKey.length);
+            } else {
+                // Pad (note that this will enable a key space smaller than
+                // the full size of the ECKeyPair space).
+                System.arraycopy(privateKey, 0, copy, 32 - privateKey.length, privateKey.length);
+            }
+
+            privateKey = copy;
+        }
+
+        return new ECKeyPair(privateKey);
+    }
+
+}

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/crypto/RadixECKeyPairs.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/crypto/RadixECKeyPairs.java
@@ -3,6 +3,7 @@ package com.radixdlt.client.core.crypto;
 import org.radix.crypto.Hash;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 public class RadixECKeyPairs {
 
@@ -30,9 +31,7 @@ public class RadixECKeyPairs {
      * @throws IllegalArgumentException if the seed is empty or a null pointer.
      */
     public ECKeyPair generateKeyPairFromSeed(byte[] seed) {
-        if (seed == null) {
-            throw new IllegalArgumentException("Seed must not be null");
-        }
+        Objects.requireNonNull(seed, "Seed must not be null");
 
         if (seed.length == 0) {
             throw new IllegalArgumentException("Seed must not be empty");

--- a/radixdlt-java/src/test/java/com/radixdlt/client/core/crypto/ECKeyPairGeneratorFromSeedTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/core/crypto/ECKeyPairGeneratorFromSeedTest.java
@@ -1,0 +1,50 @@
+package com.radixdlt.client.core.crypto;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertThat;
+
+public class ECKeyPairGeneratorFromSeedTest {
+
+    @BeforeClass
+    public static void beforeSuite() {
+        // Ensure the BouncyCastle providers are loaded into memory
+        // (because BouncyCastle SHA-256 is used in "seed" tests).
+        ECKeyPairGenerator.newInstance();
+    }
+
+    @Test
+    public void when_generating_two_default_key_pairs__they_should_have_different_private_keys() {
+        byte[] privateKey1 = ECKeyPairGenerator
+                .newInstance()
+                .generateKeyPair()
+                .getPrivateKey();
+
+        byte[] privateKey2 = ECKeyPairGenerator
+                .newInstance()
+                .generateKeyPair()
+                .getPrivateKey();
+
+        assertThat(privateKey1, not(equalTo(privateKey2)));
+    }
+
+    @Test
+    public void when_generating_two_key_pairs_from_same_seed__they_should_have_same_private_keys() {
+        byte[] seed = "seed".getBytes();
+        byte[] privateKey1 = ECKeyPairGenerator
+                .newInstance()
+                .generateKeyPairFromSeed(seed)
+                .getPrivateKey();
+
+        byte[] privateKey2 = ECKeyPairGenerator
+                .newInstance()
+                .generateKeyPairFromSeed(seed)
+                .getPrivateKey();
+
+        assertThat(privateKey1, equalTo(privateKey2));
+    }
+
+}

--- a/radixdlt-java/src/test/java/com/radixdlt/client/core/crypto/ECKeyPairTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/core/crypto/ECKeyPairTest.java
@@ -1,18 +1,60 @@
 package com.radixdlt.client.core.crypto;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertThat;
+
 public class ECKeyPairTest {
-	@Test
-	public void decryptBadEncryptedDataWithGoodEncryptedPrivateKeyShouldThrowCryptoException() {
-		ECKeyPair keyPair = ECKeyPairGenerator.newInstance().generateKeyPair();
-		ECKeyPair privateKey = ECKeyPairGenerator.newInstance().generateKeyPair();
 
-		EncryptedPrivateKey encryptedPrivateKey = privateKey.encryptPrivateKey(keyPair.getPublicKey());
+    @BeforeClass
+    public static void beforeSuite() {
+        // Ensure the BouncyCastle providers are loaded into memory
+        // (because SHA-256 is used in "seed" tests).
+        ECKeyPairGenerator.newInstance();
+    }
 
-		assertThatThrownBy(() -> keyPair.decrypt(new byte[] {0}, encryptedPrivateKey))
-			.isInstanceOf(CryptoException.class);
-	}
+    @Test
+    public void decrypt_bad_encrypted_data_with_good_encrypted_private_key__should_throw_CryptoException() {
+        ECKeyPair keyPair = ECKeyPairGenerator.newInstance().generateKeyPair();
+        ECKeyPair privateKey = ECKeyPairGenerator.newInstance().generateKeyPair();
+
+        EncryptedPrivateKey encryptedPrivateKey = privateKey.encryptPrivateKey(keyPair.getPublicKey());
+
+        assertThatThrownBy(() -> keyPair.decrypt(new byte[]{0}, encryptedPrivateKey))
+                .isInstanceOf(CryptoException.class);
+    }
+
+    @Test
+    public void when_generating_two_default_key_pairs__they_should_have_different_private_keys() {
+        byte[] privateKey1 = ECKeyPairGenerator
+                .newInstance()
+                .generateKeyPair()
+                .getPrivateKey();
+
+        byte[] privateKey2 = ECKeyPairGenerator
+                .newInstance()
+                .generateKeyPair()
+                .getPrivateKey();
+
+        assertThat(privateKey1, not(equalTo(privateKey2)));
+    }
+
+    @Test
+    public void when_generating_two_key_pairs_from_same_seed__they_should_have_same_private_keys() {
+        byte[] seed = "seed".getBytes();
+        byte[] privateKey1 = ECKeyPair
+                .fromSeed(seed)
+                .getPrivateKey();
+
+        byte[] privateKey2 = ECKeyPair
+                .fromSeed(seed)
+                .getPrivateKey();
+
+        assertThat(privateKey1, equalTo(privateKey2));
+    }
+
 }

--- a/radixdlt-java/src/test/java/com/radixdlt/client/core/crypto/ECKeyPairTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/core/crypto/ECKeyPairTest.java
@@ -1,21 +1,10 @@
 package com.radixdlt.client.core.crypto;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertThat;
 
 public class ECKeyPairTest {
-
-    @BeforeClass
-    public static void beforeSuite() {
-        // Ensure the BouncyCastle providers are loaded into memory
-        // (because SHA-256 is used in "seed" tests).
-        ECKeyPairGenerator.newInstance();
-    }
 
     @Test
     public void decrypt_bad_encrypted_data_with_good_encrypted_private_key__should_throw_CryptoException() {
@@ -26,35 +15,6 @@ public class ECKeyPairTest {
 
         assertThatThrownBy(() -> keyPair.decrypt(new byte[]{0}, encryptedPrivateKey))
                 .isInstanceOf(CryptoException.class);
-    }
-
-    @Test
-    public void when_generating_two_default_key_pairs__they_should_have_different_private_keys() {
-        byte[] privateKey1 = ECKeyPairGenerator
-                .newInstance()
-                .generateKeyPair()
-                .getPrivateKey();
-
-        byte[] privateKey2 = ECKeyPairGenerator
-                .newInstance()
-                .generateKeyPair()
-                .getPrivateKey();
-
-        assertThat(privateKey1, not(equalTo(privateKey2)));
-    }
-
-    @Test
-    public void when_generating_two_key_pairs_from_same_seed__they_should_have_same_private_keys() {
-        byte[] seed = "seed".getBytes();
-        byte[] privateKey1 = ECKeyPair
-                .fromSeed(seed)
-                .getPrivateKey();
-
-        byte[] privateKey2 = ECKeyPair
-                .fromSeed(seed)
-                .getPrivateKey();
-
-        assertThat(privateKey1, equalTo(privateKey2));
     }
 
 }

--- a/radixdlt-java/src/test/java/com/radixdlt/client/core/crypto/RadixECKeyPairsTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/core/crypto/RadixECKeyPairsTest.java
@@ -13,7 +13,7 @@ public class RadixECKeyPairsTest {
     public static void beforeSuite() {
         // Ensure the BouncyCastle providers are loaded into memory
         // (because BouncyCastle SHA-256 is used in "seed" tests).
-        ECKeyPairGenerator.newInstance();
+        ECKeyPairGenerator.install();
     }
 
     @Test

--- a/radixdlt-java/src/test/java/com/radixdlt/client/core/crypto/RadixECKeyPairsTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/core/crypto/RadixECKeyPairsTest.java
@@ -7,7 +7,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 
-public class ECKeyPairGeneratorFromSeedTest {
+public class RadixECKeyPairsTest {
 
     @BeforeClass
     public static void beforeSuite() {
@@ -34,12 +34,12 @@ public class ECKeyPairGeneratorFromSeedTest {
     @Test
     public void when_generating_two_key_pairs_from_same_seed__they_should_have_same_private_keys() {
         byte[] seed = "seed".getBytes();
-        byte[] privateKey1 = ECKeyPairGenerator
+        byte[] privateKey1 = RadixECKeyPairs
                 .newInstance()
                 .generateKeyPairFromSeed(seed)
                 .getPrivateKey();
 
-        byte[] privateKey2 = ECKeyPairGenerator
+        byte[] privateKey2 = RadixECKeyPairs
                 .newInstance()
                 .generateKeyPairFromSeed(seed)
                 .getPrivateKey();

--- a/radixdlt-java/src/test/java/com/radixdlt/client/core/crypto/RadixECKeyPairsTestJUnit5.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/core/crypto/RadixECKeyPairsTestJUnit5.java
@@ -1,0 +1,52 @@
+package com.radixdlt.client.core.crypto;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertThat;
+
+public class RadixECKeyPairsTestJUnit5 {
+
+    @BeforeEach
+    public void beforeSuite() {
+        // Ensure the BouncyCastle providers are loaded into memory
+        // (because BouncyCastle SHA-256 is used in "seed" tests).
+        ECKeyPairGenerator.install();
+    }
+
+    @Test
+    @DisplayName("Given privateKey1 and privateKey2 When we compare them Then they should be different")
+    public void generateAndCompareTwoPrivateKeys() {
+        byte[] privateKey1 = ECKeyPairGenerator
+                .newInstance()
+                .generateKeyPair()
+                .getPrivateKey();
+
+        byte[] privateKey2 = ECKeyPairGenerator
+                .newInstance()
+                .generateKeyPair()
+                .getPrivateKey();
+
+        assertThat(privateKey1, not(equalTo(privateKey2)));
+    }
+
+    @Test
+    @DisplayName("Given privateKey1 and privateKey2 with same seed When we compare them Then they should be the same")
+    public void generateAndCompareTwoPrivateKeysWithSameSeedInput() {
+        byte[] seed = "seed".getBytes();
+        byte[] privateKey1 = RadixECKeyPairs
+                .newInstance()
+                .generateKeyPairFromSeed(seed)
+                .getPrivateKey();
+
+        byte[] privateKey2 = RadixECKeyPairs
+                .newInstance()
+                .generateKeyPairFromSeed(seed)
+                .getPrivateKey();
+
+        assertThat(privateKey1, equalTo(privateKey2));
+    }
+}


### PR DESCRIPTION
I have replaced JUnit4 with JUnit5 with some new testCompile dependencies which keep it backwards compatible.

In order to quickly compare the difference I have duplicated RadixECKeyPairsTest naming it RadixECKeyPairsTestJUnit5

To see what annotations are available and how they compare to JUnit4 please see https://junit.org/junit5/docs/current/user-guide/#writing-tests-annotations

JUnit5 offers a bunch more of powerful features which can significantly reduce then number of code lines and keep things much neater with its annotations. 

A feature to consider is the possibility of using the Nested annotation which is basically using inner classes where Test methods use a common variable. This allows to shorten the @DisplayName even further since the "Given" part would be common and a @DisplayName can be placed on top of the inner class.

Also, in case this is missed, when tests are run the @DisplayName is shown instead of the method signatures.