### PR TITLE
Adding expected expect hexstring for hash for empty model and serialised model.

### DIFF
--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/Atom.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/Atom.java
@@ -152,7 +152,7 @@ public final class Atom extends SerializableObject {
 	}
 
 	public RadixHash getHash() {
-		return RadixHash.of(Serialize.getInstance().toDson(this, DsonOutput.Output.HASH));
+		return RadixHash.of(toDson());
 	}
 
 	public EUID getHid() {

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/RadixHash.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/RadixHash.java
@@ -4,13 +4,13 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
-import okio.ByteString;
 import org.bouncycastle.util.encoders.Base64;
 import org.radix.common.ID.EUID;
 
 import com.radixdlt.client.core.crypto.ECPublicKey;
 import com.radixdlt.client.core.crypto.ECSignature;
 import com.radixdlt.client.core.util.Hash;
+import org.radix.utils.primitives.Bytes;
 
 public final class RadixHash {
 	private final byte[] hash;
@@ -75,5 +75,7 @@ public final class RadixHash {
 		return Base64.toBase64String(hash);
 	}
 
-	public String toHexString() { return ByteString.of(hash).hex(); }
+	public String toHexString() {
+		return Bytes.toHexString(hash);
+	}
 }

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/RadixHash.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/RadixHash.java
@@ -4,6 +4,7 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
+import okio.ByteString;
 import org.bouncycastle.util.encoders.Base64;
 import org.radix.common.ID.EUID;
 
@@ -73,4 +74,6 @@ public final class RadixHash {
 	public String toString() {
 		return Base64.toBase64String(hash);
 	}
+
+	public String toHexString() { return ByteString.of(hash).hex(); }
 }

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/pow/ProofOfWork.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/pow/ProofOfWork.java
@@ -1,10 +1,10 @@
 package com.radixdlt.client.core.pow;
 
 import com.radixdlt.client.core.atoms.RadixHash;
-import okio.ByteString;
 
 import java.nio.ByteBuffer;
 import org.bouncycastle.util.encoders.Base64;
+import org.radix.utils.primitives.Bytes;
 
 public class ProofOfWork {
 	private final long nonce;
@@ -20,7 +20,7 @@ public class ProofOfWork {
 	}
 
 	public String getTargetHex() {
-		return ByteString.of(target).hex();
+		return Bytes.toHexString(target);
 	}
 
 	public long getNonce() {
@@ -33,7 +33,7 @@ public class ProofOfWork {
 		byteBuffer.putInt(magic);
 		byteBuffer.put(seed);
 		byteBuffer.putLong(nonce);
-		String hashHex = ByteString.of(RadixHash.of(byteBuffer.array()).toByteArray()).hex();
+		String hashHex = Bytes.toHexString(RadixHash.of(byteBuffer.array()).toByteArray());
 		if (hashHex.compareTo(targetHex) > 0) {
 			throw new ProofOfWorkException(hashHex, targetHex);
 		}

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/pow/ProofOfWorkBuilder.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/pow/ProofOfWorkBuilder.java
@@ -1,7 +1,7 @@
 package com.radixdlt.client.core.pow;
 
 import com.radixdlt.client.core.atoms.RadixHash;
-import okio.ByteString;
+import org.radix.utils.primitives.Bytes;
 
 import java.nio.ByteBuffer;
 import java.util.BitSet;
@@ -25,12 +25,12 @@ public class ProofOfWorkBuilder {
 		buffer.putInt(magic);
 		buffer.put(seed);
 
-		String targetHex = ByteString.of(target).hex();
+		String targetHex = Bytes.toHexString(target);
 
 		while (true) {
 			buffer.position(32 + 4);
 			buffer.putLong(nonce);
-			String hashHex = ByteString.of(RadixHash.of(buffer.array()).toByteArray()).hex();
+			String hashHex = Bytes.toHexString(RadixHash.of(buffer.array()).toByteArray());
 			if (hashHex.compareTo(targetHex) < 0) {
 				return new ProofOfWork(nonce, magic, seed, target);
 			}

--- a/radixdlt-java/src/main/java/org/radix/common/ID/EUID.java
+++ b/radixdlt-java/src/main/java/org/radix/common/ID/EUID.java
@@ -171,9 +171,13 @@ public final class EUID implements Comparable<EUID> {
 		return this.value.hashCode();
 	}
 
+	public String toHexString() {
+		return Bytes.toHexString(value.toByteArray());
+	}
+
 	@Override
 	public String toString() {
-		return Bytes.toHexString(value.toByteArray());
+		return toHexString();
 	}
 
 	private static Int128 ringClosest(Int128 a, Int128 b) {

--- a/radixdlt-java/src/test/java/com/radixdlt/client/core/atoms/AtomTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/core/atoms/AtomTest.java
@@ -19,6 +19,8 @@ public class AtomTest {
 		assertTrue(atom.getDataParticles().isEmpty());
 		assertTrue(atom.getConsumables(Spin.UP).isEmpty());
 		assertTrue(atom.getConsumables(Spin.DOWN).isEmpty());
+		/// The origin of these hashes are this library it self, commit: acbc5307cf5c9f7e1c30300f7438ef5dbc3bb629
+		/// These hashes can be used as a reference for other Radix libraries, e.g. Swift.
 		assertEquals("bf6a73657269616c697a65721a001ed1516776657273696f6e1864ff", ByteString.of(atom.toDson()).hex());
 		assertEquals("1b1cff72cb4f79d2eb50b5fb2777d65bebb5cad146e2006f25cde7a53445ffe7", atom.getHash().toHexString());
 		assertEquals("1b1cff72cb4f79d2eb50b5fb2777d65b", atom.getHid().toHexString());

--- a/radixdlt-java/src/test/java/com/radixdlt/client/core/atoms/AtomTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/core/atoms/AtomTest.java
@@ -6,8 +6,8 @@ import static org.junit.Assert.assertTrue;
 
 import com.radixdlt.client.core.atoms.particles.Spin;
 import com.radixdlt.client.core.util.Hash;
-import okio.ByteString;
 import org.junit.Test;
+import org.radix.utils.primitives.Bytes;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Collections;
@@ -21,7 +21,7 @@ public class AtomTest {
 		assertTrue(atom.getConsumables(Spin.DOWN).isEmpty());
 		/// The origin of these hashes are this library it self, commit: acbc5307cf5c9f7e1c30300f7438ef5dbc3bb629
 		/// These hashes can be used as a reference for other Radix libraries, e.g. Swift.
-		assertEquals("bf6a73657269616c697a65721a001ed1516776657273696f6e1864ff", ByteString.of(atom.toDson()).hex());
+		assertEquals("bf6a73657269616c697a65721a001ed1516776657273696f6e1864ff", Bytes.toHexString(atom.toDson()));
 		assertEquals("1b1cff72cb4f79d2eb50b5fb2777d65bebb5cad146e2006f25cde7a53445ffe7", atom.getHash().toHexString());
 		assertEquals("1b1cff72cb4f79d2eb50b5fb2777d65b", atom.getHid().toHexString());
 		assertEquals(new Long(0), atom.getTimestamp());

--- a/radixdlt-java/src/test/java/com/radixdlt/client/core/atoms/AtomTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/core/atoms/AtomTest.java
@@ -16,11 +16,9 @@ public class AtomTest {
 		assertTrue(atom.getDataParticles().isEmpty());
 		assertTrue(atom.getConsumables(Spin.UP).isEmpty());
 		assertTrue(atom.getConsumables(Spin.DOWN).isEmpty());
-		assertNotNull(atom.getHash());
-		assertNotNull(atom.getHid());
+		assertEquals("1b1cff72cb4f79d2eb50b5fb2777d65bebb5cad146e2006f25cde7a53445ffe7", atom.getHash().toHexString());
+		assertEquals("1b1cff72cb4f79d2eb50b5fb2777d65b", atom.getHid().toHexString());
 		assertEquals(new Long(0), atom.getTimestamp());
-		assertNotNull(atom.toString());
-
 		assertEquals(atom, new Atom(Collections.emptyList()));
 	}
 }

--- a/radixdlt-java/src/test/java/com/radixdlt/client/core/atoms/AtomTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/core/atoms/AtomTest.java
@@ -5,8 +5,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.radixdlt.client.core.atoms.particles.Spin;
+import com.radixdlt.client.core.util.Hash;
+import okio.ByteString;
 import org.junit.Test;
 
+import java.io.UnsupportedEncodingException;
 import java.util.Collections;
 
 public class AtomTest {
@@ -16,6 +19,7 @@ public class AtomTest {
 		assertTrue(atom.getDataParticles().isEmpty());
 		assertTrue(atom.getConsumables(Spin.UP).isEmpty());
 		assertTrue(atom.getConsumables(Spin.DOWN).isEmpty());
+		assertEquals("bf6a73657269616c697a65721a001ed1516776657273696f6e1864ff", ByteString.of(atom.toDson()).hex());
 		assertEquals("1b1cff72cb4f79d2eb50b5fb2777d65bebb5cad146e2006f25cde7a53445ffe7", atom.getHash().toHexString());
 		assertEquals("1b1cff72cb4f79d2eb50b5fb2777d65b", atom.getHid().toHexString());
 		assertEquals(new Long(0), atom.getTimestamp());

--- a/radixdlt-java/src/test/java/com/radixdlt/client/util/HashTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/util/HashTest.java
@@ -1,0 +1,26 @@
+package com.radixdlt.client.util;
+
+import com.radixdlt.client.core.util.Hash;
+import okio.ByteString;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class HashTest {
+
+    @Test
+    public void testDoubleSha256Hash() {
+        byte[] data = new byte[0];
+        try {
+            data = "Hello Radix".getBytes("UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+        byte[] singleHash = Hash.sha256(data);
+        byte[] doubleHash = Hash.sha256(singleHash);
+        assertEquals("374d9dc94c1252acf828cdfb94946cf808cb112aa9760a2e6216c14b4891f934", ByteString.of(singleHash).hex());
+        assertEquals("fd6be8b4b12276857ac1b63594bf38c01327bd6e8ae0eb4b0c6e253563cc8cc7", ByteString.of(doubleHash).hex());
+    }
+}

--- a/radixdlt-java/src/test/java/com/radixdlt/client/util/HashTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/util/HashTest.java
@@ -1,8 +1,8 @@
 package com.radixdlt.client.util;
 
 import com.radixdlt.client.core.util.Hash;
-import okio.ByteString;
 import org.junit.Test;
+import org.radix.utils.primitives.Bytes;
 
 import java.nio.charset.StandardCharsets;
 
@@ -19,7 +19,7 @@ public class HashTest {
         // These hashes as just the result of running the sha256 once and output the values
         // These are then used as reference for other libraries, especially Swift which
         // lacks native Sha256 methods.
-        assertEquals("374d9dc94c1252acf828cdfb94946cf808cb112aa9760a2e6216c14b4891f934", ByteString.of(singleHash).hex());
-        assertEquals("fd6be8b4b12276857ac1b63594bf38c01327bd6e8ae0eb4b0c6e253563cc8cc7", ByteString.of(doubleHash).hex());
+        assertEquals("374d9dc94c1252acf828cdfb94946cf808cb112aa9760a2e6216c14b4891f934", Bytes.toHexString(singleHash));
+        assertEquals("fd6be8b4b12276857ac1b63594bf38c01327bd6e8ae0eb4b0c6e253563cc8cc7", Bytes.toHexString(doubleHash));
     }
 }

--- a/radixdlt-java/src/test/java/com/radixdlt/client/util/HashTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/util/HashTest.java
@@ -4,22 +4,21 @@ import com.radixdlt.client.core.util.Hash;
 import okio.ByteString;
 import org.junit.Test;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import static junit.framework.TestCase.assertEquals;
 
 public class HashTest {
 
     @Test
-    public void testDoubleSha256Hash() {
-        byte[] data = new byte[0];
-        try {
-            data = "Hello Radix".getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            e.printStackTrace();
-        }
+    public void test_sha256_hash_as_reference_for_other_libraries()  {
+        byte[] data = "Hello Radix".getBytes(StandardCharsets.UTF_8);
         byte[] singleHash = Hash.sha256(data);
         byte[] doubleHash = Hash.sha256(singleHash);
+
+        // These hashes as just the result of running the sha256 once and output the values
+        // These are then used as reference for other libraries, especially Swift which
+        // lacks native Sha256 methods.
         assertEquals("374d9dc94c1252acf828cdfb94946cf808cb112aa9760a2e6216c14b4891f934", ByteString.of(singleHash).hex());
         assertEquals("fd6be8b4b12276857ac1b63594bf38c01327bd6e8ae0eb4b0c6e253563cc8cc7", ByteString.of(doubleHash).hex());
     }

--- a/radixdlt-java/src/test/java/com/radixdlt/client/util/MagicByteTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/util/MagicByteTest.java
@@ -1,0 +1,19 @@
+package com.radixdlt.client.util;
+
+import com.radixdlt.client.core.address.RadixUniverseConfigs;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class MagicByteTest {
+
+    @Test
+    public void testMagicByte() {
+        int magicIntAlphanet = 281411585;
+        byte magicByte = (byte) (magicIntAlphanet & 0xff);
+        /// The origin of this byte value is this library it self, commit: acbc5307cf5c9f7e1c30300f7438ef5dbc3bb629
+        /// This value can be used as a reference for other Radix libraries, e.g. Swift.
+        byte expected = (byte) 1;
+        assertEquals(expected, magicByte);
+    }
+}

--- a/radixdlt-java/src/test/java/org/radix/serialization2/AtomSerializationTest.java
+++ b/radixdlt-java/src/test/java/org/radix/serialization2/AtomSerializationTest.java
@@ -1,17 +1,19 @@
 package org.radix.serialization2;
 
+import com.radixdlt.client.core.atoms.RadixHash;
 import org.junit.Test;
 import org.radix.serialization2.client.Serialize;
 
 import com.radixdlt.client.core.atoms.Atom;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class AtomSerializationTest {
 
 	@Test
 	public void testAtomSerialization() {
-		String atom = "{\"dataParticles\":[{\"bytes\":\":byt:0AGgg7FFonQOWyDN0CbvbSED9Lwy7NQs17U34hb0pu+ds"
+		String atomString = "{\"dataParticles\":[{\"bytes\":\":byt:0AGgg7FFonQOWyDN0CbvbSED9Lwy7NQs17U34hb0pu+ds"
 				+ "/EIzxoqZ6UkYEWoYYK2Sx0AAAAQ7DvCu1Mw3rAsMW50OroUR26DLNRsdj+3eMYf1KNgMH8MgDlQfVkSDL4/u03SP"
 				+ "cro\",\"serializer\":473758768,\"version\":100},{\"metaData\":{\"application\":\":str:en"
 				+ "cryptor\",\"contentType\":\":str:application/json\"},\"bytes\":\":byt:WyJvWE1xTGcvWWtiNS"
@@ -42,13 +44,9 @@ public class AtomSerializationTest {
 				+ ":AL3/nYW7FGVRNndA3x1tRBS4vfPKrGHLKTGwcDEhYCcp\",\"s\":\":byt:AIDk+93m2xSNpBO6WO+Pim25k0u"
 				+ "yqaBf8E1TwRhOZfcm\",\"serializer\":-434788200,\"version\":100}},\"chronoParticle\":{\"ti"
 				+ "mestamps\":{\"default\":1539178735739},\"serializer\":1080087081,\"version\":100}}";
-		Atom a = Serialize.getInstance().fromJson(atom, Atom.class);
-		assertNotNull(a);
-		byte[] hashBytes = a.getHash().toByteArray();
-		for (int i = 0; i < hashBytes.length; ++i) {
-			System.out.format("%02x", hashBytes[i] & 0xFF);
-		}
-		System.out.println();
+		Atom atom = Serialize.getInstance().fromJson(atomString, Atom.class);
+		assertNotNull(atom);
+		assertEquals("1b1cff72cb4f79d2eb50b5fb2777d65bebb5cad146e2006f25cde7a53445ffe7", atom.getHash().toHexString());
 	}
 
 }


### PR DESCRIPTION
Adding comparisons in tests of atoms for hash, against an expected hex string, so that we more easily can verify correctness between libraries.