### PR TITLE
Renaming method in Atom having obsolete names such as "consumables" (…

### DIFF
--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/data/AtomToDecryptedMessageMapper.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/data/AtomToDecryptedMessageMapper.java
@@ -40,7 +40,7 @@ public class AtomToDecryptedMessageMapper implements AtomToExecutedActionsMapper
 
 	@Override
 	public Observable<DecryptedMessage> map(Atom atom, RadixIdentity identity) {
-		final Optional<MessageParticle> bytesParticle = atom.getDataParticles().stream()
+		final Optional<MessageParticle> bytesParticle = atom.getMessageParticles().stream()
 			.filter(p -> !"encryptor".equals(p.getMetaData("application")))
 			.findFirst();
 
@@ -55,7 +55,7 @@ public class AtomToDecryptedMessageMapper implements AtomToExecutedActionsMapper
 
 		bytesParticle.ifPresent(p -> metaData.compute("application", (k, v) -> p.getMetaData("application")));
 
-		final Optional<MessageParticle> encryptorParticle = atom.getDataParticles().stream()
+		final Optional<MessageParticle> encryptorParticle = atom.getMessageParticles().stream()
 			.filter(p -> "encryptor".equals(p.getMetaData("application")))
 			.findAny();
 		metaData.put("encrypted", encryptorParticle.isPresent());

--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/AtomToTokenTransfersMapper.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/AtomToTokenTransfersMapper.java
@@ -78,7 +78,7 @@ public class AtomToTokenTransfersMapper implements AtomToExecutedActionsMapper<T
 					}
 				}
 				final Optional<MessageParticle> bytesParticle =
-					atom.getDataParticles().stream()
+					atom.getMessageParticles().stream()
 						.filter(p -> !"encryptor".equals(p.getMetaData("application")))
 						.findFirst();
 
@@ -88,7 +88,7 @@ public class AtomToTokenTransfersMapper implements AtomToExecutedActionsMapper<T
 					Map<String, Object> metaData = new HashMap<>();
 
 					final Optional<MessageParticle> encryptorParticle =
-						atom.getDataParticles().stream()
+						atom.getMessageParticles().stream()
 							.filter(p -> "encryptor".equals(p.getMetaData("application")))
 							.findAny();
 					metaData.put("encrypted", encryptorParticle.isPresent());

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/Atom.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/atoms/Atom.java
@@ -132,13 +132,13 @@ public final class Atom extends SerializableObject {
 		return Optional.ofNullable(this.signatures).map(sigs -> sigs.get(uid.toString()));
 	}
 
-	public Stream<SpunParticle<OwnedTokensParticle>> consumables() {
+	public Stream<SpunParticle<OwnedTokensParticle>> ownedTokensParticles() {
 		return this.spunParticles()
 			.filter(s -> s.getParticle() instanceof OwnedTokensParticle)
 			.map(s -> (SpunParticle<OwnedTokensParticle>) s);
 }
 
-	public List<OwnedTokensParticle> getConsumables(Spin spin) {
+	public List<OwnedTokensParticle> getOwnedTokensParticles(Spin spin) {
 		return this.spunParticles()
 			.filter(s -> s.getSpin() == spin)
 			.map(SpunParticle::getParticle)
@@ -159,7 +159,7 @@ public final class Atom extends SerializableObject {
 		return this.getHash().toEUID();
 	}
 
-	public List<MessageParticle> getDataParticles() {
+	public List<MessageParticle> getMessageParticles() {
 		return this.spunParticles()
 			.map(SpunParticle::getParticle)
 			.filter(p -> p instanceof MessageParticle)
@@ -168,7 +168,7 @@ public final class Atom extends SerializableObject {
 	}
 
 	public Map<TokenClassReference, Map<ECPublicKey, BigInteger>> tokenSummary() {
-		return this.consumables()
+		return this.ownedTokensParticles()
 			.collect(Collectors.groupingBy(
 				s -> s.getParticle().getTokenClassReference(),
 				Collectors.groupingBy(

--- a/radixdlt-java/src/main/java/com/radixdlt/client/core/ledger/RadixAtomValidator.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/core/ledger/RadixAtomValidator.java
@@ -29,7 +29,7 @@ public class RadixAtomValidator implements AtomValidator {
 	public void validateSignatures(Atom atom) throws AtomValidationException {
 		RadixHash hash = atom.getHash();
 
-		Optional<AtomValidationException> exception = atom.getConsumables(Spin.DOWN).stream()
+		Optional<AtomValidationException> exception = atom.getOwnedTokensParticles(Spin.DOWN).stream()
 			.map(down -> {
 				if (down.getOwnersPublicKeys().isEmpty()) {
 					return new AtomValidationException("No owners in particle");

--- a/radixdlt-java/src/test/java/com/radixdlt/client/application/RadixApplicationAPITest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/application/RadixApplicationAPITest.java
@@ -174,7 +174,7 @@ public class RadixApplicationAPITest {
 		RadixAddress address = mock(RadixAddress.class);
 		when(address.getPublicKey()).thenReturn(mock(ECPublicKey.class));
 		Atom atom = mock(Atom.class);
-		when(atom.getDataParticles()).thenReturn(Collections.emptyList());
+		when(atom.getMessageParticles()).thenReturn(Collections.emptyList());
 		AtomObservation atomObservation = AtomObservation.storeAtom(atom);
 
 		Ledger ledger = mock(Ledger.class);

--- a/radixdlt-java/src/test/java/com/radixdlt/client/core/atoms/AtomTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/core/atoms/AtomTest.java
@@ -13,9 +13,9 @@ public class AtomTest {
 	@Test
 	public void testEmptyAtom() {
 		Atom atom = new Atom(Collections.emptyList());
-		assertTrue(atom.getDataParticles().isEmpty());
-		assertTrue(atom.getConsumables(Spin.UP).isEmpty());
-		assertTrue(atom.getConsumables(Spin.DOWN).isEmpty());
+		assertTrue(atom.getMessageParticles().isEmpty());
+		assertTrue(atom.getOwnedTokensParticles(Spin.UP).isEmpty());
+		assertTrue(atom.getOwnedTokensParticles(Spin.DOWN).isEmpty());
 		/// The origin of these hashes are this library it self, commit: acbc5307cf5c9f7e1c30300f7438ef5dbc3bb629
 		/// These hashes can be used as a reference for other Radix libraries, e.g. Swift.
 		assertEquals("bf6a73657269616c697a65721a001ed1516776657273696f6e1864ff", Bytes.toHexString(atom.toDson()));

--- a/radixdlt-java/src/test/java/com/radixdlt/client/core/ledger/RadixAtomValidatorTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/core/ledger/RadixAtomValidatorTest.java
@@ -41,7 +41,7 @@ public class RadixAtomValidatorTest {
 		Atom atom = mock(Atom.class);
 		when(atom.getHash()).thenReturn(hash);
 		when(atom.getSignature(any())).thenReturn(Optional.empty());
-		when(atom.getConsumables(Spin.DOWN)).thenReturn(Arrays.asList(consumer));
+		when(atom.getOwnedTokensParticles(Spin.DOWN)).thenReturn(Arrays.asList(consumer));
 
 		RadixAtomValidator validator = RadixAtomValidator.getInstance();
 		assertThatThrownBy(() -> validator.validateSignatures(atom))


### PR DESCRIPTION
…instead of the actual "OwnedTokensParticle") and renamed "getDataParticle" to "getMessageParticles"