### PR TITLE
Remove sonartype snapshot as maven repo in build.gralde

### DIFF
--- a/radixdlt-java/build.gradle
+++ b/radixdlt-java/build.gradle
@@ -30,7 +30,6 @@ apply plugin: 'com.adarshr.test-logger'
 
 repositories {
     jcenter()
-    maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     maven { url 'https://jitpack.io' }
 }
 


### PR DESCRIPTION
Without this fix `gradle clean test` fails on my machine:

```
➜  radixdlt-java git:(rc/1.0-beta.7) git status
On branch rc/1.0-beta.7
Your branch is up to date with 'origin/rc/1.0-beta.7'.
nothing to commit, working tree clean
➜  radixdlt-java git:(rc/1.0-beta.7) ./gradlew clean test
> Task :radixdlt-java:compileJava FAILED
FAILURE: Build failed with an exception.
* What went wrong:
Could not resolve all files for configuration ':radixdlt-java:compileClasspath'.
> Could not resolve com.github.radixdlt:radixdlt-java-common:rc~1.0-beta.2-SNAPSHOT.
  Required by:
      project :radixdlt-java
   > Could not resolve com.github.radixdlt:radixdlt-java-common:rc~1.0-beta.2-SNAPSHOT.
      > Unable to load Maven meta-data from https://oss.sonatype.org/content/repositories/snapshots/com/github/radixdlt/radixdlt-java-common/rc~1.0-beta.2-SNAPSHOT/maven-metadata.xml.
         > Could not get resource 'https://oss.sonatype.org/content/repositories/snapshots/com/github/radixdlt/radixdlt-java-common/rc~1.0-beta.2-SNAPSHOT/maven-metadata.xml'.
            > Could not GET 'https://oss.sonatype.org/content/repositories/snapshots/com/github/radixdlt/radixdlt-java-common/rc~1.0-beta.2-SNAPSHOT/maven-metadata.xml'.
               > Read timed out
* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
* Get more help at https://help.gradle.org
BUILD FAILED in 30s
4 actionable tasks: 1 executed, 3 up-to-date
➜  radixdlt-java git:(rc/1.0-beta.7)
```

Not sure how this bug got passed all our checks... But this seems to fix it!