### PR TITLE
Basic delegated staking

### DIFF
--- a/examples/src/main/java/com/radixdlt/client/examples/StakingExample.java
+++ b/examples/src/main/java/com/radixdlt/client/examples/StakingExample.java
@@ -27,10 +27,12 @@ import com.radixdlt.client.application.RadixApplicationAPI.Result;
 import com.radixdlt.client.application.RadixApplicationAPI.Transaction;
 import com.radixdlt.client.application.identity.RadixIdentities;
 import com.radixdlt.client.application.identity.RadixIdentity;
+import com.radixdlt.client.application.translate.ShardedParticleStateId;
 import com.radixdlt.client.application.translate.tokens.CreateTokenAction;
 import com.radixdlt.client.application.translate.tokens.CreateTokenAction.TokenSupplyType;
 import com.radixdlt.client.application.translate.tokens.MintTokensAction;
 import com.radixdlt.client.application.translate.tokens.TokenUnitConversions;
+import com.radixdlt.client.atommodel.tokens.TransferrableTokensParticle;
 import com.radixdlt.client.core.Bootstrap;
 import com.radixdlt.identifiers.RRI;
 import com.radixdlt.identifiers.RadixAddress;
@@ -55,7 +57,7 @@ public class StakingExample {
 		System.out.println("My public key: " + api.getPublicKey());
 
 		// Create a unique identifier for the token
-		RRI tokenRRI = RRI.of(api.getAddress(), "JOSH");
+		RRI tokenRRI = RRI.of(api.getAddress(), "COOKIE");
 
 		// Observe all past and future transactions
 		api.observeTokenTransfers()
@@ -69,13 +71,12 @@ public class StakingExample {
 		Transaction transaction = api.createTransaction();
 		transaction.stage(CreateTokenAction.create(
 			tokenRRI,
-			"Joshy Token",
-			"The Best Coin Ever",
-			BigDecimal.ZERO,
+			"Cookie Token",
+			"Cookiemonster approved.",
+			BigDecimal.valueOf(100000.0),
 			TokenUnitConversions.getMinimumGranularity(),
 			TokenSupplyType.MUTABLE
 		));
-		transaction.stage(MintTokensAction.create(tokenRRI, api.getAddress(), BigDecimal.valueOf(1000000.0)));
 		Result createTokenAndMint = transaction.commitAndPush();
 		createTokenAndMint.toObservable().blockingSubscribe(System.out::println);
 
@@ -83,17 +84,17 @@ public class StakingExample {
 		System.out.println(api.getTokenDef(tokenRRI));
 
 		// Stake tokens
-		api.stakeTokens(BigDecimal.valueOf(10000.0), tokenRRI, address1).toObservable()
-			.subscribe(System.out::println, Throwable::printStackTrace);
+		System.out.println("staking 1");
+		api.stakeTokens(BigDecimal.valueOf(10000.0), tokenRRI, address1).blockUntilComplete();
 
 		// Redelegate staked tokens
-		api.redelegateStakedTokens(BigDecimal.valueOf(5000.0), tokenRRI, address1, address2).toObservable()
-			.subscribe(System.out::println, Throwable::printStackTrace);
+		System.out.println("redelegating staked 1");
+		api.redelegateStakedTokens(BigDecimal.valueOf(5000.0), tokenRRI, address1, address2).blockUntilComplete();
 
 		// Unstake tokens
-		api.unstakeTokens(BigDecimal.valueOf(5000.0), tokenRRI, address1).toObservable()
-			.subscribe(System.out::println, Throwable::printStackTrace);
-		api.unstakeTokens(BigDecimal.valueOf(5000.0), tokenRRI, address2).toObservable()
-			.subscribe(System.out::println, Throwable::printStackTrace);
+		System.out.println("unstaking 1");
+		api.unstakeTokens(BigDecimal.valueOf(5000.0), tokenRRI, address1).blockUntilComplete();
+		System.out.println("unstaking 2");
+		api.unstakeTokens(BigDecimal.valueOf(5000.0), tokenRRI, address2).blockUntilComplete();
 	}
 }

--- a/examples/src/main/java/com/radixdlt/client/examples/StakingExample.java
+++ b/examples/src/main/java/com/radixdlt/client/examples/StakingExample.java
@@ -87,13 +87,13 @@ public class StakingExample {
 			.subscribe(System.out::println, Throwable::printStackTrace);
 
 		// Redelegate staked tokens
-//		api.redelegateStakedTokens(BigDecimal.valueOf(5000.0), tokenRRI, address1, address2).toObservable()
-//			.subscribe(System.out::println, Throwable::printStackTrace);
+		api.redelegateStakedTokens(BigDecimal.valueOf(5000.0), tokenRRI, address1, address2).toObservable()
+			.subscribe(System.out::println, Throwable::printStackTrace);
 
 		// Unstake tokens
-//		api.unstakeTokens(BigDecimal.valueOf(5000.0), tokenRRI, address1).toObservable()
-//			.subscribe(System.out::println, Throwable::printStackTrace);
-//		api.unstakeTokens(BigDecimal.valueOf(5000.0), tokenRRI, address2).toObservable()
-//			.subscribe(System.out::println, Throwable::printStackTrace);
+		api.unstakeTokens(BigDecimal.valueOf(5000.0), tokenRRI, address1).toObservable()
+			.subscribe(System.out::println, Throwable::printStackTrace);
+		api.unstakeTokens(BigDecimal.valueOf(5000.0), tokenRRI, address2).toObservable()
+			.subscribe(System.out::println, Throwable::printStackTrace);
 	}
 }

--- a/examples/src/main/java/com/radixdlt/client/examples/StakingExample.java
+++ b/examples/src/main/java/com/radixdlt/client/examples/StakingExample.java
@@ -1,0 +1,99 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the “Software”),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.radixdlt.client.examples;
+
+import com.radixdlt.client.application.RadixApplicationAPI;
+import com.radixdlt.client.application.RadixApplicationAPI.Result;
+import com.radixdlt.client.application.RadixApplicationAPI.Transaction;
+import com.radixdlt.client.application.identity.RadixIdentities;
+import com.radixdlt.client.application.identity.RadixIdentity;
+import com.radixdlt.client.application.translate.tokens.CreateTokenAction;
+import com.radixdlt.client.application.translate.tokens.CreateTokenAction.TokenSupplyType;
+import com.radixdlt.client.application.translate.tokens.MintTokensAction;
+import com.radixdlt.client.application.translate.tokens.TokenUnitConversions;
+import com.radixdlt.client.core.Bootstrap;
+import com.radixdlt.identifiers.RRI;
+import com.radixdlt.identifiers.RadixAddress;
+
+import java.math.BigDecimal;
+
+public class StakingExample {
+	public static void main(String[] args) {
+		RadixAddress address1 = RadixAddress.from("JEbhKQzBn4qJzWJFBbaPioA2GTeaQhuUjYWkanTE6N8VvvPpvM8");
+		RadixAddress address2 = RadixAddress.from("23B6fH3FekJeP6e5guhZAk6n9z4fmTo5Tngo3a11Wg5R8gsWTV2x");
+
+		// Create a new public key identity
+		final RadixIdentity radixIdentity = RadixIdentities.createNew();
+
+		// Initialize api layer
+		RadixApplicationAPI api = RadixApplicationAPI.create(Bootstrap.LOCALHOST, radixIdentity);
+
+		// Constantly sync account with network
+		api.pull();
+
+		System.out.println("My address: " + api.getAddress());
+		System.out.println("My public key: " + api.getPublicKey());
+
+		// Create a unique identifier for the token
+		RRI tokenRRI = RRI.of(api.getAddress(), "JOSH");
+
+		// Observe all past and future transactions
+		api.observeTokenTransfers()
+			.subscribe(System.out::println);
+
+		// Observe current and future total balance
+		api.observeBalance(tokenRRI)
+			.subscribe(balance -> System.out.println("My Balance: " + balance));
+
+		// Create token and mint
+		Transaction transaction = api.createTransaction();
+		transaction.stage(CreateTokenAction.create(
+			tokenRRI,
+			"Joshy Token",
+			"The Best Coin Ever",
+			BigDecimal.ZERO,
+			TokenUnitConversions.getMinimumGranularity(),
+			TokenSupplyType.MUTABLE
+		));
+		transaction.stage(MintTokensAction.create(tokenRRI, api.getAddress(), BigDecimal.valueOf(1000000.0)));
+		Result createTokenAndMint = transaction.commitAndPush();
+		createTokenAndMint.toObservable().blockingSubscribe(System.out::println);
+
+		// Get token definition
+		System.out.println(api.getTokenDef(tokenRRI));
+
+		// Stake tokens
+		api.stakeTokens(BigDecimal.valueOf(10000.0), tokenRRI, address1).toObservable()
+			.subscribe(System.out::println, Throwable::printStackTrace);
+
+		// Redelegate staked tokens
+//		api.redelegateStakedTokens(BigDecimal.valueOf(5000.0), tokenRRI, address1, address2).toObservable()
+//			.subscribe(System.out::println, Throwable::printStackTrace);
+
+		// Unstake tokens
+//		api.unstakeTokens(BigDecimal.valueOf(5000.0), tokenRRI, address1).toObservable()
+//			.subscribe(System.out::println, Throwable::printStackTrace);
+//		api.unstakeTokens(BigDecimal.valueOf(5000.0), tokenRRI, address2).toObservable()
+//			.subscribe(System.out::println, Throwable::printStackTrace);
+	}
+}

--- a/radixdlt-java/build.gradle
+++ b/radixdlt-java/build.gradle
@@ -49,6 +49,10 @@ dependencies {
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.11.0'
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'
     testCompile 'nl.jqno.equalsverifier:equalsverifier:3.1.5'
+    testCompile('com.flipkart.zjsonpatch:zjsonpatch:0.4.5') {
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+    }
 }
 
 // TODO: Consider moving to Google Checkstyle format

--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/RadixApplicationAPI.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/RadixApplicationAPI.java
@@ -55,6 +55,7 @@ import com.radixdlt.client.application.translate.tokens.MintTokensAction;
 import com.radixdlt.client.application.translate.tokens.MintTokensActionMapper;
 import com.radixdlt.client.application.translate.tokens.RedelegateStakedTokensAction;
 import com.radixdlt.client.application.translate.tokens.StakeTokensAction;
+import com.radixdlt.client.application.translate.tokens.StakeTokensMapper;
 import com.radixdlt.client.application.translate.tokens.TokenBalanceReducer;
 import com.radixdlt.client.application.translate.tokens.TokenBalanceState;
 import com.radixdlt.client.application.translate.tokens.TokenDefinitionsReducer;
@@ -158,6 +159,7 @@ public class RadixApplicationAPI {
 			.addStatefulParticlesMapper(MintTokensAction.class, new MintTokensActionMapper())
 			.addStatefulParticlesMapper(BurnTokensAction.class, new BurnTokensActionMapper())
 			.addStatefulParticlesMapper(TransferTokensAction.class, new TransferTokensToParticleGroupsMapper())
+			.addStatefulParticlesMapper(StakeTokensAction.class, new StakeTokensMapper())
 			.addStatefulParticlesMapper(RegisterValidatorAction.class, new RegisterValidatorActionMapper())
 			.addStatefulParticlesMapper(UnregisterValidatorAction.class, new UnregisterValidatorActionMapper())
 			.addReducer(new TokenDefinitionsReducer())
@@ -786,6 +788,22 @@ public class RadixApplicationAPI {
 	/**
 	 * Stakes a certain amount of a token from an address to a delegate.
 	 *
+	 * @param amount     the amount of the token type
+	 * @param token      the token type
+	 * @param delegate   the address to delegate the staked tokens to
+	 * @return result of the transaction
+	 */
+	public Result stakeTokens(
+		BigDecimal amount,
+		RRI token,
+		RadixAddress delegate
+	) {
+		return stakeTokens(amount, token, getAddress(), delegate);
+	}
+
+	/**
+	 * Stakes a certain amount of a token from an address to a delegate.
+	 *
 	 * @param from       the address to stake tokens from
 	 * @param delegate   the address to delegate the staked tokens to
 	 * @param amount     the amount of the token type
@@ -804,6 +822,24 @@ public class RadixApplicationAPI {
 		Objects.requireNonNull(delegate);
 
 		return this.execute(StakeTokensAction.create(amount, token, from, delegate));
+	}
+
+	/**
+	 * Redelegate a certain amount of a staked token from an address to a delegate.
+	 *
+	 * @param amount        the amount of the token type
+	 * @param token         the token type
+	 * @param oldDelegate   the address the staked tokens are currently delegated to
+	 * @param newDelegate   the address the staked tokens will be delegated to
+	 * @return result of the transaction
+	 */
+	public Result redelegateStakedTokens(
+		BigDecimal amount,
+		RRI token,
+		RadixAddress oldDelegate,
+		RadixAddress newDelegate
+	) {
+		return redelegateStakedTokens(amount, token, getAddress(), oldDelegate, newDelegate);
 	}
 
 	/**
@@ -830,6 +866,22 @@ public class RadixApplicationAPI {
 		Objects.requireNonNull(newDelegate);
 
 		return this.execute(RedelegateStakedTokensAction.create(amount, token, from, oldDelegate, newDelegate));
+	}
+
+	/**
+	 * Unstakes a certain amount of a token from an address to a delegate.
+	 *
+	 * @param amount     the amount of the token type
+	 * @param token      the token type
+	 * @param delegate   the address to delegate the staked tokens to
+	 * @return result of the transaction
+	 */
+	public Result unstakeTokens(
+		BigDecimal amount,
+		RRI token,
+		RadixAddress delegate
+	) {
+		return unstakeTokens(amount, token, getAddress(), delegate);
 	}
 
 	/**

--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/RadixApplicationAPI.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/RadixApplicationAPI.java
@@ -53,6 +53,8 @@ import com.radixdlt.client.application.translate.tokens.CreateTokenAction.TokenS
 import com.radixdlt.client.application.translate.tokens.CreateTokenToParticleGroupsMapper;
 import com.radixdlt.client.application.translate.tokens.MintTokensAction;
 import com.radixdlt.client.application.translate.tokens.MintTokensActionMapper;
+import com.radixdlt.client.application.translate.tokens.RedelegateStakedTokensAction;
+import com.radixdlt.client.application.translate.tokens.StakeTokensAction;
 import com.radixdlt.client.application.translate.tokens.TokenBalanceReducer;
 import com.radixdlt.client.application.translate.tokens.TokenBalanceState;
 import com.radixdlt.client.application.translate.tokens.TokenDefinitionsReducer;
@@ -62,6 +64,7 @@ import com.radixdlt.client.application.translate.tokens.TokenTransfer;
 import com.radixdlt.client.application.translate.tokens.TokenUnitConversions;
 import com.radixdlt.client.application.translate.tokens.TransferTokensAction;
 import com.radixdlt.client.application.translate.tokens.TransferTokensToParticleGroupsMapper;
+import com.radixdlt.client.application.translate.tokens.UnstakeTokensAction;
 import com.radixdlt.client.application.translate.unique.AlreadyUsedUniqueIdReasonMapper;
 import com.radixdlt.client.application.translate.unique.PutUniqueIdAction;
 import com.radixdlt.client.application.translate.unique.PutUniqueIdToParticleGroupsMapper;
@@ -778,6 +781,78 @@ public class RadixApplicationAPI {
 			TransferTokensAction.create(token, from, to, amount, attachment);
 
 		return this.execute(transferTokensAction);
+	}
+
+	/**
+	 * Stakes a certain amount of a token from an address to a delegate.
+	 *
+	 * @param from       the address to stake tokens from
+	 * @param delegate   the address to delegate the staked tokens to
+	 * @param amount     the amount of the token type
+	 * @param token      the token type
+	 * @return result of the transaction
+	 */
+	public Result stakeTokens(
+		BigDecimal amount,
+		RRI token,
+		RadixAddress from,
+		RadixAddress delegate
+	) {
+		Objects.requireNonNull(amount);
+		Objects.requireNonNull(token);
+		Objects.requireNonNull(from);
+		Objects.requireNonNull(delegate);
+
+		return this.execute(StakeTokensAction.create(amount, token, from, delegate));
+	}
+
+	/**
+	 * Redelegate a certain amount of a staked token from an address to a delegate.
+	 *
+	 * @param from          the address to stake tokens from
+	 * @param oldDelegate   the address the staked tokens are currently delegated to
+	 * @param newDelegate   the address the staked tokens will be delegated to
+	 * @param amount        the amount of the token type
+	 * @param token         the token type
+	 * @return result of the transaction
+	 */
+	public Result redelegateStakedTokens(
+		BigDecimal amount,
+		RRI token,
+		RadixAddress from,
+		RadixAddress oldDelegate,
+		RadixAddress newDelegate
+	) {
+		Objects.requireNonNull(amount);
+		Objects.requireNonNull(token);
+		Objects.requireNonNull(from);
+		Objects.requireNonNull(oldDelegate);
+		Objects.requireNonNull(newDelegate);
+
+		return this.execute(RedelegateStakedTokensAction.create(amount, token, from, oldDelegate, newDelegate));
+	}
+
+	/**
+	 * Unstakes a certain amount of a token from an address to a delegate.
+	 *
+	 * @param from       the address to stake tokens from
+	 * @param delegate   the address to delegate the staked tokens to
+	 * @param amount     the amount of the token type
+	 * @param token      the token type
+	 * @return result of the transaction
+	 */
+	public Result unstakeTokens(
+		BigDecimal amount,
+		RRI token,
+		RadixAddress from,
+		RadixAddress delegate
+	) {
+		Objects.requireNonNull(amount);
+		Objects.requireNonNull(token);
+		Objects.requireNonNull(from);
+		Objects.requireNonNull(delegate);
+
+		return this.execute(UnstakeTokensAction.create(amount, token, from, delegate));
 	}
 
 	/**

--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/RadixApplicationAPI.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/RadixApplicationAPI.java
@@ -790,7 +790,7 @@ public class RadixApplicationAPI {
 	}
 
 	/**
-	 * Stakes a certain amount of a token from an address to a delegate.
+	 * Stakes a certain amount of a token from this address to a delegate.
 	 *
 	 * @param amount     the amount of the token type
 	 * @param token      the token type
@@ -829,7 +829,7 @@ public class RadixApplicationAPI {
 	}
 
 	/**
-	 * Redelegate a certain amount of a staked token from an address to a delegate.
+	 * Redelegate a certain amount of a staked tokens of this address to another delegate.
 	 *
 	 * @param amount        the amount of the token type
 	 * @param token         the token type
@@ -847,7 +847,7 @@ public class RadixApplicationAPI {
 	}
 
 	/**
-	 * Redelegate a certain amount of a staked token from an address to a delegate.
+	 * Redelegate a certain amount of a staked tokens of an address to another delegate.
 	 *
 	 * @param from          the address to stake tokens from
 	 * @param oldDelegate   the address the staked tokens are currently delegated to
@@ -873,7 +873,7 @@ public class RadixApplicationAPI {
 	}
 
 	/**
-	 * Unstakes a certain amount of a token from an address to a delegate.
+	 * Unstakes a certain amount of a token from this address to a delegate.
 	 *
 	 * @param amount     the amount of the token type
 	 * @param token      the token type

--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/RadixApplicationAPI.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/RadixApplicationAPI.java
@@ -54,6 +54,7 @@ import com.radixdlt.client.application.translate.tokens.CreateTokenToParticleGro
 import com.radixdlt.client.application.translate.tokens.MintTokensAction;
 import com.radixdlt.client.application.translate.tokens.MintTokensActionMapper;
 import com.radixdlt.client.application.translate.tokens.RedelegateStakedTokensAction;
+import com.radixdlt.client.application.translate.tokens.RedelegateStakedTokensMapper;
 import com.radixdlt.client.application.translate.tokens.StakeTokensAction;
 import com.radixdlt.client.application.translate.tokens.StakeTokensMapper;
 import com.radixdlt.client.application.translate.tokens.TokenBalanceReducer;
@@ -66,6 +67,7 @@ import com.radixdlt.client.application.translate.tokens.TokenUnitConversions;
 import com.radixdlt.client.application.translate.tokens.TransferTokensAction;
 import com.radixdlt.client.application.translate.tokens.TransferTokensToParticleGroupsMapper;
 import com.radixdlt.client.application.translate.tokens.UnstakeTokensAction;
+import com.radixdlt.client.application.translate.tokens.UnstakeTokensMapper;
 import com.radixdlt.client.application.translate.unique.AlreadyUsedUniqueIdReasonMapper;
 import com.radixdlt.client.application.translate.unique.PutUniqueIdAction;
 import com.radixdlt.client.application.translate.unique.PutUniqueIdToParticleGroupsMapper;
@@ -160,6 +162,8 @@ public class RadixApplicationAPI {
 			.addStatefulParticlesMapper(BurnTokensAction.class, new BurnTokensActionMapper())
 			.addStatefulParticlesMapper(TransferTokensAction.class, new TransferTokensToParticleGroupsMapper())
 			.addStatefulParticlesMapper(StakeTokensAction.class, new StakeTokensMapper())
+			.addStatefulParticlesMapper(RedelegateStakedTokensAction.class, new RedelegateStakedTokensMapper())
+			.addStatefulParticlesMapper(UnstakeTokensAction.class, new UnstakeTokensMapper())
 			.addStatefulParticlesMapper(RegisterValidatorAction.class, new RegisterValidatorActionMapper())
 			.addStatefulParticlesMapper(UnregisterValidatorAction.class, new UnregisterValidatorActionMapper())
 			.addReducer(new TokenDefinitionsReducer())

--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/RedelegateStakedTokensAction.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/RedelegateStakedTokensAction.java
@@ -28,6 +28,9 @@ import com.radixdlt.identifiers.RadixAddress;
 
 import java.math.BigDecimal;
 
+/**
+ * An action for redelegating staked tokens from one delegate to another
+ */
 public class RedelegateStakedTokensAction implements Action {
 	private final RadixAddress from;
 	private final RadixAddress oldDelegate;

--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/RedelegateStakedTokensAction.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/RedelegateStakedTokensAction.java
@@ -1,0 +1,99 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the “Software”),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.radixdlt.client.application.translate.tokens;
+
+import com.radixdlt.client.application.translate.Action;
+import com.radixdlt.identifiers.RRI;
+import com.radixdlt.identifiers.RadixAddress;
+
+import java.math.BigDecimal;
+
+public class RedelegateStakedTokensAction implements Action {
+	private final RadixAddress from;
+	private final RadixAddress oldDelegate;
+	private final RadixAddress newDelegate;
+	private final RRI rri;
+	private final BigDecimal amount;
+
+	private RedelegateStakedTokensAction(
+		BigDecimal amount,
+		RRI rri,
+		RadixAddress from,
+		RadixAddress oldDelegate,
+		RadixAddress newDelegate
+	) {
+		if (amount.stripTrailingZeros().scale() > TokenUnitConversions.getTokenScale()) {
+			throw new IllegalArgumentException("Amount must scale by " + TokenUnitConversions.getTokenScale());
+		}
+
+		this.from = from;
+		this.oldDelegate = oldDelegate;
+		this.newDelegate = newDelegate;
+		this.rri = rri;
+		this.amount = amount;
+	}
+
+	public static RedelegateStakedTokensAction create(
+		BigDecimal amount,
+		RRI rri,
+		RadixAddress from,
+		RadixAddress oldDelegate,
+		RadixAddress newDelegate
+	) {
+		return new RedelegateStakedTokensAction(
+			amount,
+			rri,
+			from,
+			oldDelegate,
+			newDelegate
+		);
+	}
+
+	public RadixAddress getFrom() {
+		return from;
+	}
+
+	public RadixAddress getOldDelegate() {
+		return oldDelegate;
+	}
+
+	public RadixAddress getNewDelegate() {
+		return newDelegate;
+	}
+
+	public RRI getRRI() {
+		return rri;
+	}
+
+	public BigDecimal getAmount() {
+		return amount;
+	}
+
+	@Override
+	public String toString() {
+		return String.format(
+			"REDELEGATE STAKED TOKENS %s %s OF %s FROM %s TO %s",
+			amount, rri.getName(), from, oldDelegate, newDelegate
+		);
+	}
+}

--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/RedelegateStakedTokensMapper.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/RedelegateStakedTokensMapper.java
@@ -26,7 +26,6 @@ import com.radixdlt.client.application.translate.ShardedParticleStateId;
 import com.radixdlt.client.application.translate.StageActionException;
 import com.radixdlt.client.application.translate.StatefulActionToParticleGroupsMapper;
 import com.radixdlt.client.atommodel.tokens.StakedTokensParticle;
-import com.radixdlt.client.atommodel.tokens.StakedTokensParticle;
 import com.radixdlt.client.core.atoms.ParticleGroup;
 import com.radixdlt.client.core.atoms.particles.Particle;
 import com.radixdlt.client.core.atoms.particles.Spin;

--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/StakeTokensAction.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/StakeTokensAction.java
@@ -1,0 +1,90 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the “Software”),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.radixdlt.client.application.translate.tokens;
+
+import com.radixdlt.client.application.translate.Action;
+import com.radixdlt.identifiers.RRI;
+import com.radixdlt.identifiers.RadixAddress;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class StakeTokensAction implements Action {
+	private final RadixAddress from;
+	private final RadixAddress delegate;
+	private final RRI rri;
+	private final BigDecimal amount;
+
+	private StakeTokensAction(
+		BigDecimal amount,
+		RRI rri,
+		RadixAddress from,
+		RadixAddress delegate
+	) {
+		if (amount.stripTrailingZeros().scale() > TokenUnitConversions.getTokenScale()) {
+			throw new IllegalArgumentException("Amount must scale by " + TokenUnitConversions.getTokenScale());
+		}
+
+		this.from = from;
+		this.delegate = delegate;
+		this.rri = rri;
+		this.amount = amount;
+	}
+
+	public static StakeTokensAction create(
+		BigDecimal amount,
+		RRI rri,
+		RadixAddress from,
+		RadixAddress delegate
+	) {
+		return new StakeTokensAction(
+			amount,
+			rri,
+			from,
+			delegate
+		);
+	}
+
+	public RadixAddress getFrom() {
+		return from;
+	}
+
+	public RadixAddress getDelegate() {
+		return delegate;
+	}
+
+	public RRI getRRI() {
+		return rri;
+	}
+
+	public BigDecimal getAmount() {
+		return amount;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("STAKE TOKENS %s %s OF %s TO %s", amount, rri.getName(), from, delegate);
+	}
+}

--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/StakeTokensAction.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/StakeTokensAction.java
@@ -28,6 +28,9 @@ import com.radixdlt.identifiers.RadixAddress;
 
 import java.math.BigDecimal;
 
+/**
+ * An action for staking tokens from an address to a certain delegate
+ */
 public class StakeTokensAction implements Action {
 	private final RadixAddress from;
 	private final RadixAddress delegate;

--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/StakeTokensAction.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/StakeTokensAction.java
@@ -27,9 +27,6 @@ import com.radixdlt.identifiers.RRI;
 import com.radixdlt.identifiers.RadixAddress;
 
 import java.math.BigDecimal;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 public class StakeTokensAction implements Action {
 	private final RadixAddress from;

--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/StakeTokensMapper.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/StakeTokensMapper.java
@@ -1,0 +1,111 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the “Software”),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.radixdlt.client.application.translate.tokens;
+
+import com.radixdlt.client.application.translate.ShardedParticleStateId;
+import com.radixdlt.client.application.translate.StageActionException;
+import com.radixdlt.client.application.translate.StatefulActionToParticleGroupsMapper;
+import com.radixdlt.client.atommodel.tokens.StakedTokensParticle;
+import com.radixdlt.client.atommodel.tokens.TransferrableTokensParticle;
+import com.radixdlt.client.core.atoms.ParticleGroup;
+import com.radixdlt.client.core.atoms.particles.Particle;
+import com.radixdlt.client.core.atoms.particles.Spin;
+import com.radixdlt.client.core.fungible.FungibleParticleTransitioner;
+import com.radixdlt.client.core.fungible.FungibleParticleTransitioner.FungibleParticleTransition;
+import com.radixdlt.client.core.fungible.NotEnoughFungiblesException;
+import com.radixdlt.identifiers.RRI;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Maps a stake tokens action to the particles necessary to be included in an atom.
+ */
+public class StakeTokensMapper implements StatefulActionToParticleGroupsMapper<StakeTokensAction> {
+	public StakeTokensMapper() {
+	}
+
+	@Override
+	public Set<ShardedParticleStateId> requiredState(StakeTokensAction transfer) {
+		return Collections.singleton(ShardedParticleStateId.of(TransferrableTokensParticle.class, transfer.getFrom()));
+	}
+
+	@Override
+	public List<ParticleGroup> mapToParticleGroups(StakeTokensAction transfer, Stream<Particle> store) throws StageActionException {
+		final RRI tokenRef = transfer.getRRI();
+
+		List<TransferrableTokensParticle> tokenConsumables = store
+			.map(TransferrableTokensParticle.class::cast)
+			.filter(p -> p.getTokenDefinitionReference().equals(tokenRef))
+			.collect(Collectors.toList());
+
+		final FungibleParticleTransitioner<TransferrableTokensParticle, StakedTokensParticle> transitioner =
+			new FungibleParticleTransitioner<>(
+				(amt, consumable) -> new StakedTokensParticle(
+					transfer.getDelegate(),
+					amt,
+					consumable.getGranularity(),
+					transfer.getFrom(),
+					System.nanoTime(),
+					consumable.getTokenDefinitionReference(),
+					System.currentTimeMillis() / 60000L + 60000L,
+					consumable.getTokenPermissions()
+				),
+				stakedTokens -> stakedTokens,
+				(amt, consumable) -> new TransferrableTokensParticle(
+					amt,
+					consumable.getGranularity(),
+					consumable.getAddress(),
+					System.nanoTime(),
+					consumable.getTokenDefinitionReference(),
+					System.currentTimeMillis() / 60000L + 60000L,
+					consumable.getTokenPermissions()
+				),
+				tokens -> tokens,
+				TransferrableTokensParticle::getAmount
+			);
+
+
+		try {
+			FungibleParticleTransition<TransferrableTokensParticle, StakedTokensParticle> transition = transitioner.createTransition(
+				tokenConsumables,
+				TokenUnitConversions.unitsToSubunits(transfer.getAmount())
+			);
+
+			ParticleGroup.ParticleGroupBuilder particleGroupBuilder = ParticleGroup.builder();
+			transition.getRemoved().stream().map(t -> (Particle) t).forEach(p -> particleGroupBuilder.addParticle(p, Spin.DOWN));
+			transition.getMigrated().stream().map(t -> (Particle) t).forEach(p -> particleGroupBuilder.addParticle(p, Spin.UP));
+			transition.getTransitioned().stream().map(t -> (Particle) t).forEach(p -> particleGroupBuilder.addParticle(p, Spin.UP));
+
+			return Collections.singletonList(particleGroupBuilder.build());
+		} catch (NotEnoughFungiblesException e) {
+			throw new InsufficientFundsException(
+				tokenRef, TokenUnitConversions.subunitsToUnits(e.getCurrent()), transfer.getAmount()
+			);
+		}
+
+	}
+}

--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/StakeTokensMapper.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/StakeTokensMapper.java
@@ -96,9 +96,9 @@ public class StakeTokensMapper implements StatefulActionToParticleGroupsMapper<S
 			);
 
 			ParticleGroup.ParticleGroupBuilder particleGroupBuilder = ParticleGroup.builder();
-			transition.getRemoved().stream().map(t -> (Particle) t).forEach(p -> particleGroupBuilder.addParticle(p, Spin.DOWN));
-			transition.getMigrated().stream().map(t -> (Particle) t).forEach(p -> particleGroupBuilder.addParticle(p, Spin.UP));
-			transition.getTransitioned().stream().map(t -> (Particle) t).forEach(p -> particleGroupBuilder.addParticle(p, Spin.UP));
+			transition.getRemoved().forEach(p -> particleGroupBuilder.addParticle(p, Spin.DOWN));
+			transition.getMigrated().forEach(p -> particleGroupBuilder.addParticle(p, Spin.UP));
+			transition.getTransitioned().forEach(p -> particleGroupBuilder.addParticle(p, Spin.UP));
 
 			return Collections.singletonList(particleGroupBuilder.build());
 		} catch (NotEnoughFungiblesException e) {

--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/UnstakeTokensAction.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/UnstakeTokensAction.java
@@ -1,0 +1,87 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the “Software”),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.radixdlt.client.application.translate.tokens;
+
+import com.radixdlt.client.application.translate.Action;
+import com.radixdlt.identifiers.RRI;
+import com.radixdlt.identifiers.RadixAddress;
+
+import java.math.BigDecimal;
+
+public class UnstakeTokensAction implements Action {
+	private final RadixAddress from;
+	private final RadixAddress delegate;
+	private final RRI rri;
+	private final BigDecimal amount;
+
+	private UnstakeTokensAction(
+		BigDecimal amount,
+		RRI rri,
+		RadixAddress from,
+		RadixAddress delegate
+	) {
+		if (amount.stripTrailingZeros().scale() > TokenUnitConversions.getTokenScale()) {
+			throw new IllegalArgumentException("Amount must scale by " + TokenUnitConversions.getTokenScale());
+		}
+
+		this.from = from;
+		this.delegate = delegate;
+		this.rri = rri;
+		this.amount = amount;
+	}
+
+	public static UnstakeTokensAction create(
+		BigDecimal amount,
+		RRI rri,
+		RadixAddress from,
+		RadixAddress delegate
+	) {
+		return new UnstakeTokensAction(
+			amount,
+			rri,
+			from,
+			delegate
+		);
+	}
+
+	public RadixAddress getFrom() {
+		return from;
+	}
+
+	public RadixAddress getDelegate() {
+		return delegate;
+	}
+
+	public RRI getRRI() {
+		return rri;
+	}
+
+	public BigDecimal getAmount() {
+		return amount;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("UNSTAKE TOKENS %s %s OF %s FROM %s", amount, rri.getName(), from, delegate);
+	}
+}

--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/UnstakeTokensAction.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/UnstakeTokensAction.java
@@ -28,6 +28,9 @@ import com.radixdlt.identifiers.RadixAddress;
 
 import java.math.BigDecimal;
 
+/**
+ * An action for unstaking staked tokens from an address staked to a certain delegate
+ */
 public class UnstakeTokensAction implements Action {
 	private final RadixAddress from;
 	private final RadixAddress delegate;

--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/UnstakeTokensMapper.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/UnstakeTokensMapper.java
@@ -50,7 +50,7 @@ public class UnstakeTokensMapper implements StatefulActionToParticleGroupsMapper
 
 	@Override
 	public Set<ShardedParticleStateId> requiredState(UnstakeTokensAction action) {
-		return Collections.singleton(ShardedParticleStateId.of(TransferrableTokensParticle.class, action.getFrom()));
+		return Collections.singleton(ShardedParticleStateId.of(StakedTokensParticle.class, action.getFrom()));
 	}
 
 	@Override

--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/UnstakeTokensMapper.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/UnstakeTokensMapper.java
@@ -96,9 +96,9 @@ public class UnstakeTokensMapper implements StatefulActionToParticleGroupsMapper
 			);
 
 			ParticleGroup.ParticleGroupBuilder particleGroupBuilder = ParticleGroup.builder();
-			transition.getRemoved().stream().map(t -> (Particle) t).forEach(p -> particleGroupBuilder.addParticle(p, Spin.DOWN));
-			transition.getMigrated().stream().map(t -> (Particle) t).forEach(p -> particleGroupBuilder.addParticle(p, Spin.UP));
-			transition.getTransitioned().stream().map(t -> (Particle) t).forEach(p -> particleGroupBuilder.addParticle(p, Spin.UP));
+			transition.getRemoved().forEach(p -> particleGroupBuilder.addParticle(p, Spin.DOWN));
+			transition.getMigrated().forEach(p -> particleGroupBuilder.addParticle(p, Spin.UP));
+			transition.getTransitioned().forEach(p -> particleGroupBuilder.addParticle(p, Spin.UP));
 
 			return Collections.singletonList(particleGroupBuilder.build());
 		} catch (NotEnoughFungiblesException e) {

--- a/radixdlt-java/src/main/java/com/radixdlt/client/atommodel/tokens/StakedTokensParticle.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/atommodel/tokens/StakedTokensParticle.java
@@ -167,13 +167,15 @@ public final class StakedTokensParticle extends Particle implements Accountable,
 
 	@Override
 	public String toString() {
-		return String.format("%s[%s:%s:%s:%s:%s:%s]",
+		return String.format("%s[%s:%s:%s:%s:%s:%s:%s]",
 			getClass().getSimpleName(),
-			String.valueOf(tokenDefinitionReference),
-			String.valueOf(amount),
-			String.valueOf(granularity),
-			String.valueOf(address),
+			tokenDefinitionReference,
+			amount,
+			granularity,
+			address,
+			delegateAddress,
 			planck,
-			nonce);
+			nonce
+		);
 	}
 }

--- a/radixdlt-java/src/main/java/com/radixdlt/client/atommodel/tokens/StakedTokensParticle.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/atommodel/tokens/StakedTokensParticle.java
@@ -1,0 +1,179 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the “Software”),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.radixdlt.client.atommodel.tokens;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import com.radixdlt.client.atommodel.Accountable;
+import com.radixdlt.client.atommodel.Ownable;
+import com.radixdlt.client.atommodel.tokens.MutableSupplyTokenDefinitionParticle.TokenTransition;
+import com.radixdlt.client.core.atoms.particles.Particle;
+import com.radixdlt.identifiers.RRI;
+import com.radixdlt.identifiers.RadixAddress;
+import com.radixdlt.serialization.DsonOutput;
+import com.radixdlt.serialization.DsonOutput.Output;
+import com.radixdlt.serialization.SerializerId2;
+import com.radixdlt.utils.UInt256;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ *  A particle which represents an amount of staked fungible tokens
+ *  owned by some key owner, stored in an account and staked to a delegate address.
+ */
+@SerializerId2("radix.particles.staked_tokens")
+public final class StakedTokensParticle extends Particle implements Accountable, Ownable {
+	@JsonProperty("delegateAddress")
+	@DsonOutput(Output.ALL)
+	private RadixAddress delegateAddress;
+
+	@JsonProperty("address")
+	@DsonOutput(Output.ALL)
+	private RadixAddress address;
+
+	@JsonProperty("tokenDefinitionReference")
+	@DsonOutput(Output.ALL)
+	private RRI tokenDefinitionReference;
+
+	@JsonProperty("granularity")
+	@DsonOutput(Output.ALL)
+	private UInt256 granularity;
+
+	@JsonProperty("planck")
+	@DsonOutput(Output.ALL)
+	private long planck;
+
+	@JsonProperty("nonce")
+	@DsonOutput(Output.ALL)
+	private long nonce;
+
+	@JsonProperty("amount")
+	@DsonOutput(Output.ALL)
+	private UInt256 amount;
+
+	private Map<TokenTransition, TokenPermission> tokenPermissions;
+
+	protected StakedTokensParticle() {
+		this.tokenPermissions = ImmutableMap.of();
+	}
+
+	public StakedTokensParticle(
+		RadixAddress delegateAddress, UInt256 amount,
+		UInt256 granularity,
+		RadixAddress address,
+		long nonce,
+		RRI tokenDefinitionReference,
+		long planck,
+		Map<TokenTransition, TokenPermission> tokenPermissions
+	) {
+		super(address.euid());
+
+		// Redundant null check added for completeness
+		Objects.requireNonNull(amount, "amount is required");
+		if (amount.isZero()) {
+			throw new IllegalArgumentException("Amount is zero");
+		}
+
+		this.delegateAddress = delegateAddress;
+		this.address = address;
+		this.tokenDefinitionReference = tokenDefinitionReference;
+		this.granularity = granularity;
+		this.planck = planck;
+		this.nonce = nonce;
+		this.amount = amount;
+		this.tokenPermissions = ImmutableMap.copyOf(tokenPermissions);
+	}
+
+	public Map<TokenTransition, TokenPermission> getTokenPermissions() {
+		return tokenPermissions;
+	}
+
+	@JsonProperty("permissions")
+	@DsonOutput(value = {Output.ALL})
+	private Map<String, String> getJsonPermissions() {
+		return this.tokenPermissions.entrySet().stream()
+			.collect(Collectors.toMap(e -> e.getKey().name().toLowerCase(), e -> e.getValue().name().toLowerCase()));
+	}
+
+	@JsonProperty("permissions")
+	private void setJsonPermissions(Map<String, String> permissions) {
+		if (permissions != null) {
+			this.tokenPermissions = permissions.entrySet().stream()
+				.collect(Collectors.toMap(
+					e -> TokenTransition.valueOf(e.getKey().toUpperCase()), e -> TokenPermission.valueOf(e.getValue().toUpperCase())
+				));
+		} else {
+			throw new IllegalArgumentException("Permissions cannot be null.");
+		}
+	}
+
+	@Override
+	public Set<RadixAddress> getAddresses() {
+		return Collections.singleton(this.address);
+	}
+
+	@Override
+	public RadixAddress getAddress() {
+		return this.address;
+	}
+
+	public RadixAddress getDelegateAddress() {
+		return delegateAddress;
+	}
+
+	public long getNonce() {
+		return this.nonce;
+	}
+
+	public RRI getTokenDefinitionReference() {
+		return RRI.of(tokenDefinitionReference.getAddress(), tokenDefinitionReference.getName());
+	}
+
+	public UInt256 getAmount() {
+		return this.amount;
+	}
+
+	public UInt256 getGranularity() {
+		return this.granularity;
+	}
+
+	public long getPlanck() {
+		return this.planck;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("%s[%s:%s:%s:%s:%s:%s]",
+			getClass().getSimpleName(),
+			String.valueOf(tokenDefinitionReference),
+			String.valueOf(amount),
+			String.valueOf(granularity),
+			String.valueOf(address),
+			planck,
+			nonce);
+	}
+}

--- a/radixdlt-java/src/main/java/com/radixdlt/client/atommodel/tokens/StakedTokensParticle.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/atommodel/tokens/StakedTokensParticle.java
@@ -167,15 +167,7 @@ public final class StakedTokensParticle extends Particle implements Accountable,
 
 	@Override
 	public String toString() {
-		return String.format("%s[%s:%s:%s:%s:%s:%s:%s]",
-			getClass().getSimpleName(),
-			tokenDefinitionReference,
-			amount,
-			granularity,
-			address,
-			delegateAddress,
-			planck,
-			nonce
-		);
+		return String.format("%s[%s:%s:%s:%s:%s:%s:%s]", getClass().getSimpleName(), tokenDefinitionReference, amount,
+			granularity, address, delegateAddress, planck, nonce);
 	}
 }

--- a/radixdlt-java/src/main/java/com/radixdlt/client/serialization/Serialize.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/serialization/Serialize.java
@@ -23,6 +23,7 @@
 package com.radixdlt.client.serialization;
 
 import com.radixdlt.client.atommodel.rri.RRIParticle;
+import com.radixdlt.client.atommodel.tokens.StakedTokensParticle;
 import com.radixdlt.client.atommodel.tokens.UnallocatedTokensParticle;
 import com.radixdlt.client.atommodel.validators.RegisteredValidatorParticle;
 import com.radixdlt.client.atommodel.validators.UnregisteredValidatorParticle;
@@ -77,6 +78,7 @@ public final class Serialize {
 				FixedSupplyTokenDefinitionParticle.class,
 				UnallocatedTokensParticle.class,
 				TransferrableTokensParticle.class,
+				StakedTokensParticle.class,
 				UniqueParticle.class,
 				RegisteredValidatorParticle.class,
 				UnregisteredValidatorParticle.class,

--- a/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/RedelegateStakedTokensActionSerializeTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/RedelegateStakedTokensActionSerializeTest.java
@@ -1,0 +1,60 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the “Software”),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.radixdlt.client.application.translate.tokens;
+
+import com.radixdlt.identifiers.RRI;
+import com.radixdlt.identifiers.RadixAddress;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class RedelegateStakedTokensActionSerializeTest {
+	public static final RadixAddress OLD_DELEGATE = RadixAddress.from("JEbhKQzBn4qJzWJFBbaPioA2GTeaQhuUjYWkanTE6N8VvvPpvM8");
+	public static final RadixAddress NEW_DELEGATE = RadixAddress.from("23B6fH3FekJeP6e5guhZAk6n9z4fmTo5Tngo3a11Wg5R8gsWTV2x");
+	public static final RadixAddress ADDRESS = RadixAddress.from("23B6fH3FekJeP6e5guhZAk6n9z4fmTo5Tngo3a11Wg5R8gsWTV2x");
+	public static final RRI TOKEN = RRI.of(ADDRESS, "COOKIE");
+	public static final BigDecimal AMOUNT = BigDecimal.ONE;
+
+	@Test
+	public void testGetters() {
+		RedelegateStakedTokensAction a = get();
+		assertEquals(AMOUNT, a.getAmount());
+		assertEquals(TOKEN, a.getRRI());
+		assertEquals(ADDRESS, a.getFrom());
+		assertEquals(OLD_DELEGATE, a.getOldDelegate());
+		assertEquals(NEW_DELEGATE, a.getNewDelegate());
+	}
+
+	private static RedelegateStakedTokensAction get() {
+		return RedelegateStakedTokensAction.create(
+			AMOUNT,
+			TOKEN,
+			ADDRESS,
+			OLD_DELEGATE,
+			NEW_DELEGATE
+		);
+	}
+}

--- a/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/RedelegateStakedTokensMapperTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/RedelegateStakedTokensMapperTest.java
@@ -22,10 +22,12 @@
 
 package com.radixdlt.client.application.translate.tokens;
 
+import com.google.common.collect.ImmutableMap;
 import com.radixdlt.client.application.translate.ShardedParticleStateId;
 import com.radixdlt.client.atommodel.tokens.StakedTokensParticle;
 import com.radixdlt.identifiers.RRI;
 import com.radixdlt.identifiers.RadixAddress;
+import com.radixdlt.utils.UInt256;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -39,11 +41,11 @@ import static org.mockito.Mockito.when;
 public class RedelegateStakedTokensMapperTest {
 
 	@Test
-	public void createTransactionWithNoFunds() {
+	public void when_redelegating_tokens_without_funds__then_error_is_thrown() {
 		RadixAddress address = mock(RadixAddress.class);
 
 		RRI token = mock(RRI.class);
-		when(token.getName()).thenReturn("TEST");
+		when(token.getName()).thenReturn("COOKIE");
 
 		RedelegateStakedTokensAction action = mock(RedelegateStakedTokensAction.class);
 		when(action.getAmount()).thenReturn(new BigDecimal("1.0"));
@@ -57,6 +59,34 @@ public class RedelegateStakedTokensMapperTest {
 
 		assertThatThrownBy(() -> transferTranslator.mapToParticleGroups(action, Stream.empty()))
 			.isEqualTo(new InsufficientFundsException(token, BigDecimal.ZERO, new BigDecimal("1.0")));
+	}
+
+	@Test
+	public void when_redelegating_tokens_with_funds__then_error_is_not_thrown() {
+		RadixAddress address1 = RadixAddress.from("JEbhKQzBn4qJzWJFBbaPioA2GTeaQhuUjYWkanTE6N8VvvPpvM8");
+		RadixAddress address2 = RadixAddress.from("23B6fH3FekJeP6e5guhZAk6n9z4fmTo5Tngo3a11Wg5R8gsWTV2x");
+
+		RRI token = RRI.of(address1, "COOKIE");
+
+		RedelegateStakedTokensAction action = mock(RedelegateStakedTokensAction.class);
+		when(action.getAmount()).thenReturn(new BigDecimal(1));
+		when(action.getFrom()).thenReturn(address1);
+		when(action.getRRI()).thenReturn(token);
+
+		RedelegateStakedTokensMapper transferTranslator = new RedelegateStakedTokensMapper();
+
+		transferTranslator.mapToParticleGroups(action, Stream.of(
+			new StakedTokensParticle(
+				address2,
+				UInt256.MAX_VALUE,
+				UInt256.ONE,
+				address1,
+				0,
+				token,
+				0,
+				ImmutableMap.of()
+			)
+		));
 	}
 
 }

--- a/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/RedelegateStakedTokensMapperTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/RedelegateStakedTokensMapperTest.java
@@ -1,0 +1,63 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the “Software”),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.radixdlt.client.application.translate.tokens;
+
+import com.radixdlt.client.application.translate.ShardedParticleStateId;
+import com.radixdlt.client.atommodel.tokens.StakedTokensParticle;
+import com.radixdlt.client.atommodel.tokens.TransferrableTokensParticle;
+import com.radixdlt.identifiers.RRI;
+import com.radixdlt.identifiers.RadixAddress;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RedelegateStakedTokensMapperTest {
+
+	@Test
+	public void createTransactionWithNoFunds() {
+		RadixAddress address = mock(RadixAddress.class);
+
+		RRI token = mock(RRI.class);
+		when(token.getName()).thenReturn("TEST");
+
+		RedelegateStakedTokensAction action = mock(RedelegateStakedTokensAction.class);
+		when(action.getAmount()).thenReturn(new BigDecimal("1.0"));
+		when(action.getFrom()).thenReturn(address);
+		when(action.getRRI()).thenReturn(token);
+
+		RedelegateStakedTokensMapper transferTranslator = new RedelegateStakedTokensMapper();
+
+		assertThat(transferTranslator.requiredState(action))
+			.containsExactly(ShardedParticleStateId.of(StakedTokensParticle.class, address));
+
+		assertThatThrownBy(() -> transferTranslator.mapToParticleGroups(action, Stream.empty()))
+			.isEqualTo(new InsufficientFundsException(token, BigDecimal.ZERO, new BigDecimal("1.0")));
+	}
+
+}

--- a/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/RedelegateStakedTokensMapperTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/RedelegateStakedTokensMapperTest.java
@@ -24,7 +24,6 @@ package com.radixdlt.client.application.translate.tokens;
 
 import com.radixdlt.client.application.translate.ShardedParticleStateId;
 import com.radixdlt.client.atommodel.tokens.StakedTokensParticle;
-import com.radixdlt.client.atommodel.tokens.TransferrableTokensParticle;
 import com.radixdlt.identifiers.RRI;
 import com.radixdlt.identifiers.RadixAddress;
 import org.junit.Test;

--- a/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/StakeTokensActionSerializeTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/StakeTokensActionSerializeTest.java
@@ -1,0 +1,57 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the “Software”),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.radixdlt.client.application.translate.tokens;
+
+import com.radixdlt.identifiers.RRI;
+import com.radixdlt.identifiers.RadixAddress;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class StakeTokensActionSerializeTest {
+	public static final RadixAddress DELEGATE_ADDRESS = RadixAddress.from("JEbhKQzBn4qJzWJFBbaPioA2GTeaQhuUjYWkanTE6N8VvvPpvM8");
+	public static final RadixAddress ADDRESS = RadixAddress.from("23B6fH3FekJeP6e5guhZAk6n9z4fmTo5Tngo3a11Wg5R8gsWTV2x");
+	public static final RRI TOKEN = RRI.of(ADDRESS, "COOKIE");
+	public static final BigDecimal AMOUNT = BigDecimal.ONE;
+
+	@Test
+	public void testGetters() {
+		StakeTokensAction a = get();
+		assertEquals(AMOUNT, a.getAmount());
+		assertEquals(TOKEN, a.getRRI());
+		assertEquals(ADDRESS, a.getFrom());
+		assertEquals(DELEGATE_ADDRESS, a.getDelegate());
+	}
+
+	private static StakeTokensAction get() {
+		return StakeTokensAction.create(
+			AMOUNT,
+			TOKEN,
+			ADDRESS,
+			DELEGATE_ADDRESS
+		);
+	}
+}

--- a/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/StakeTokensMapperTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/StakeTokensMapperTest.java
@@ -29,7 +29,6 @@ import com.radixdlt.identifiers.RadixAddress;
 import org.junit.Test;
 
 import java.math.BigDecimal;
-import java.util.Collections;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/StakeTokensMapperTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/StakeTokensMapperTest.java
@@ -22,10 +22,12 @@
 
 package com.radixdlt.client.application.translate.tokens;
 
+import com.google.common.collect.ImmutableMap;
 import com.radixdlt.client.application.translate.ShardedParticleStateId;
 import com.radixdlt.client.atommodel.tokens.TransferrableTokensParticle;
 import com.radixdlt.identifiers.RRI;
 import com.radixdlt.identifiers.RadixAddress;
+import com.radixdlt.utils.UInt256;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -39,7 +41,7 @@ import static org.mockito.Mockito.when;
 public class StakeTokensMapperTest {
 
 	@Test
-	public void createTransactionWithNoFunds() {
+	public void when_staking_tokens_without_funds__then_error_is_not_thrown() {
 		RadixAddress address = mock(RadixAddress.class);
 
 		RRI token = mock(RRI.class);
@@ -57,6 +59,32 @@ public class StakeTokensMapperTest {
 
 		assertThatThrownBy(() -> transferTranslator.mapToParticleGroups(action, Stream.empty()))
 			.isEqualTo(new InsufficientFundsException(token, BigDecimal.ZERO, new BigDecimal("1.0")));
+	}
+
+	@Test
+	public void when_staking_tokens_with_funds__then_error_is_not_thrown() {
+		RadixAddress address1 = RadixAddress.from("JEbhKQzBn4qJzWJFBbaPioA2GTeaQhuUjYWkanTE6N8VvvPpvM8");
+
+		RRI token = RRI.of(address1, "COOKIE");
+
+		StakeTokensAction action = mock(StakeTokensAction.class);
+		when(action.getAmount()).thenReturn(new BigDecimal(1));
+		when(action.getFrom()).thenReturn(address1);
+		when(action.getRRI()).thenReturn(token);
+
+		StakeTokensMapper transferTranslator = new StakeTokensMapper();
+
+		transferTranslator.mapToParticleGroups(action, Stream.of(
+			new TransferrableTokensParticle(
+				UInt256.MAX_VALUE,
+				UInt256.ONE,
+				address1,
+				0,
+				token,
+				0,
+				ImmutableMap.of()
+			)
+		));
 	}
 
 }

--- a/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/StakeTokensMapperTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/StakeTokensMapperTest.java
@@ -1,0 +1,63 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the “Software”),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.radixdlt.client.application.translate.tokens;
+
+import com.radixdlt.client.application.translate.ShardedParticleStateId;
+import com.radixdlt.client.atommodel.tokens.TransferrableTokensParticle;
+import com.radixdlt.identifiers.RRI;
+import com.radixdlt.identifiers.RadixAddress;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class StakeTokensMapperTest {
+
+	@Test
+	public void createTransactionWithNoFunds() {
+		RadixAddress address = mock(RadixAddress.class);
+
+		RRI token = mock(RRI.class);
+		when(token.getName()).thenReturn("TEST");
+
+		StakeTokensAction action = mock(StakeTokensAction.class);
+		when(action.getAmount()).thenReturn(new BigDecimal("1.0"));
+		when(action.getFrom()).thenReturn(address);
+		when(action.getRRI()).thenReturn(token);
+
+		StakeTokensMapper transferTranslator = new StakeTokensMapper();
+
+		assertThat(transferTranslator.requiredState(action))
+			.containsExactly(ShardedParticleStateId.of(TransferrableTokensParticle.class, address));
+
+		assertThatThrownBy(() -> transferTranslator.mapToParticleGroups(action, Stream.empty()))
+			.isEqualTo(new InsufficientFundsException(token, BigDecimal.ZERO, new BigDecimal("1.0")));
+	}
+
+}

--- a/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/StakedTokensParticleSerializationTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/StakedTokensParticleSerializationTest.java
@@ -1,0 +1,71 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package com.radixdlt.client.application.translate.tokens;
+
+import com.google.common.collect.ImmutableMap;
+import com.radixdlt.client.atommodel.tokens.MutableSupplyTokenDefinitionParticle;
+import com.radixdlt.client.atommodel.tokens.StakedTokensParticle;
+import com.radixdlt.client.atommodel.tokens.TokenPermission;
+import com.radixdlt.client.util.SerializeObjectEngine;
+import com.radixdlt.identifiers.RRI;
+import com.radixdlt.identifiers.RadixAddress;
+import com.radixdlt.utils.UInt256;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StakedTokensParticleSerializationTest extends SerializeObjectEngine<StakedTokensParticle> {
+	public static final RadixAddress DELEGATE_ADDRESS = RadixAddress.from("JEbhKQzBn4qJzWJFBbaPioA2GTeaQhuUjYWkanTE6N8VvvPpvM8");
+	public static final RadixAddress ADDRESS = RadixAddress.from("23B6fH3FekJeP6e5guhZAk6n9z4fmTo5Tngo3a11Wg5R8gsWTV2x");
+	public static final RRI TOKEN = RRI.of(ADDRESS, "COOKIE");
+	public static final UInt256 AMOUNT = UInt256.EIGHT;
+	public static final UInt256 GRANULARITY = UInt256.ONE;
+	public static final int PLANCK = 100;
+	public static final int NONCE = 1;
+	public static final ImmutableMap<MutableSupplyTokenDefinitionParticle.TokenTransition, TokenPermission> TOKEN_PERMISSIONS = ImmutableMap.of();
+
+	public StakedTokensParticleSerializationTest() {
+		super(StakedTokensParticle.class, StakedTokensParticleSerializationTest::get);
+	}
+
+	@Test
+	public void testGetters() {
+		StakedTokensParticle p = get();
+		assertEquals(DELEGATE_ADDRESS, p.getDelegateAddress());
+		assertEquals(AMOUNT, p.getAmount());
+		assertEquals(GRANULARITY, p.getGranularity());
+		assertEquals(ADDRESS, p.getAddress());
+		assertEquals(NONCE, p.getNonce());
+		assertEquals(TOKEN, p.getTokenDefinitionReference());
+		assertEquals(PLANCK, p.getPlanck());
+		assertEquals(TOKEN_PERMISSIONS, p.getTokenPermissions());
+	}
+
+	private static StakedTokensParticle get() {
+		return new StakedTokensParticle(
+			DELEGATE_ADDRESS,
+			AMOUNT,
+			GRANULARITY,
+			ADDRESS,
+			NONCE,
+			TOKEN,
+			PLANCK,
+			TOKEN_PERMISSIONS
+		);
+	}
+}

--- a/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/UnstakeTokensActionSerializeTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/UnstakeTokensActionSerializeTest.java
@@ -1,0 +1,57 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the “Software”),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.radixdlt.client.application.translate.tokens;
+
+import com.radixdlt.identifiers.RRI;
+import com.radixdlt.identifiers.RadixAddress;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class UnstakeTokensActionSerializeTest {
+	public static final RadixAddress DELEGATE_ADDRESS = RadixAddress.from("JEbhKQzBn4qJzWJFBbaPioA2GTeaQhuUjYWkanTE6N8VvvPpvM8");
+	public static final RadixAddress ADDRESS = RadixAddress.from("23B6fH3FekJeP6e5guhZAk6n9z4fmTo5Tngo3a11Wg5R8gsWTV2x");
+	public static final RRI TOKEN = RRI.of(ADDRESS, "COOKIE");
+	public static final BigDecimal AMOUNT = BigDecimal.ONE;
+
+	@Test
+	public void testGetters() {
+		UnstakeTokensAction a = get();
+		assertEquals(AMOUNT, a.getAmount());
+		assertEquals(TOKEN, a.getRRI());
+		assertEquals(ADDRESS, a.getFrom());
+		assertEquals(DELEGATE_ADDRESS, a.getDelegate());
+	}
+
+	private static UnstakeTokensAction get() {
+		return UnstakeTokensAction.create(
+			AMOUNT,
+			TOKEN,
+			ADDRESS,
+			DELEGATE_ADDRESS
+		);
+	}
+}

--- a/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/UnstakeTokensMapperTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/UnstakeTokensMapperTest.java
@@ -22,10 +22,12 @@
 
 package com.radixdlt.client.application.translate.tokens;
 
+import com.google.common.collect.ImmutableMap;
 import com.radixdlt.client.application.translate.ShardedParticleStateId;
 import com.radixdlt.client.atommodel.tokens.StakedTokensParticle;
 import com.radixdlt.identifiers.RRI;
 import com.radixdlt.identifiers.RadixAddress;
+import com.radixdlt.utils.UInt256;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -39,7 +41,7 @@ import static org.mockito.Mockito.when;
 public class UnstakeTokensMapperTest {
 
 	@Test
-	public void createTransactionWithNoFunds() {
+	public void when_unstaking_tokens_without_funds__then_error_is_not_thrown() {
 		RadixAddress address = mock(RadixAddress.class);
 
 		RRI token = mock(RRI.class);
@@ -57,6 +59,35 @@ public class UnstakeTokensMapperTest {
 
 		assertThatThrownBy(() -> transferTranslator.mapToParticleGroups(action, Stream.empty()))
 			.isEqualTo(new InsufficientFundsException(token, BigDecimal.ZERO, new BigDecimal("1.0")));
+	}
+
+	@Test
+	public void when_unstaking_tokens_with_funds__then_error_is_not_thrown() {
+		RadixAddress address1 = RadixAddress.from("JEbhKQzBn4qJzWJFBbaPioA2GTeaQhuUjYWkanTE6N8VvvPpvM8");
+		RadixAddress address2 = RadixAddress.from("23B6fH3FekJeP6e5guhZAk6n9z4fmTo5Tngo3a11Wg5R8gsWTV2x");
+
+		RRI token = RRI.of(address1, "COOKIE");
+
+		UnstakeTokensAction action = mock(UnstakeTokensAction.class);
+		when(action.getAmount()).thenReturn(new BigDecimal(1));
+		when(action.getFrom()).thenReturn(address1);
+		when(action.getRRI()).thenReturn(token);
+		when(action.getDelegate()).thenReturn(address2);
+
+		UnstakeTokensMapper transferTranslator = new UnstakeTokensMapper();
+
+		transferTranslator.mapToParticleGroups(action, Stream.of(
+			new StakedTokensParticle(
+				address2,
+				UInt256.MAX_VALUE,
+				UInt256.ONE,
+				address1,
+				0,
+				token,
+				0,
+				ImmutableMap.of()
+			)
+		));
 	}
 
 }

--- a/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/UnstakeTokensMapperTest.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/application/translate/tokens/UnstakeTokensMapperTest.java
@@ -1,0 +1,62 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the “Software”),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package com.radixdlt.client.application.translate.tokens;
+
+import com.radixdlt.client.application.translate.ShardedParticleStateId;
+import com.radixdlt.client.atommodel.tokens.StakedTokensParticle;
+import com.radixdlt.identifiers.RRI;
+import com.radixdlt.identifiers.RadixAddress;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UnstakeTokensMapperTest {
+
+	@Test
+	public void createTransactionWithNoFunds() {
+		RadixAddress address = mock(RadixAddress.class);
+
+		RRI token = mock(RRI.class);
+		when(token.getName()).thenReturn("TEST");
+
+		UnstakeTokensAction action = mock(UnstakeTokensAction.class);
+		when(action.getAmount()).thenReturn(new BigDecimal("1.0"));
+		when(action.getFrom()).thenReturn(address);
+		when(action.getRRI()).thenReturn(token);
+
+		UnstakeTokensMapper transferTranslator = new UnstakeTokensMapper();
+
+		assertThat(transferTranslator.requiredState(action))
+			.containsExactly(ShardedParticleStateId.of(StakedTokensParticle.class, address));
+
+		assertThatThrownBy(() -> transferTranslator.mapToParticleGroups(action, Stream.empty()))
+			.isEqualTo(new InsufficientFundsException(token, BigDecimal.ZERO, new BigDecimal("1.0")));
+	}
+
+}

--- a/radixdlt-java/src/test/java/com/radixdlt/client/util/SerializationTestUtilsEngine.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/util/SerializationTestUtilsEngine.java
@@ -1,0 +1,61 @@
+package com.radixdlt.client.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.flipkart.zjsonpatch.JsonDiff;
+import com.radixdlt.serialization.DsonOutput;
+import com.radixdlt.serialization.Serialization;
+
+import java.io.IOException;
+
+import static org.junit.Assert.fail;
+
+/**
+ * N.B. this was copied (duplication :/ ) over from `radixdlt-java-common`,
+ * we should remove this code duplication in the future, <a href="https://radixdlt.atlassian.net/browse/RPNV1-83">here is Jira ticket
+ *  * relating to this task.<a/>
+ *
+ * Utilities for test encoding and decoding with serializers.
+ */
+final class SerializationTestUtilsEngine {
+
+	private SerializationTestUtilsEngine() {
+		throw new IllegalStateException("Can't construct");
+	}
+
+	static <T> void testEncodeDecode(T target, Class<T> cls, Serialization serialization, DsonOutput.Output output)
+			throws Exception {
+		String json1 = serialization.toJson(target, output);
+		T newTarget = serialization.fromJson(json1, cls);
+		String json2 = serialization.toJson(newTarget, output);
+		compareJson(json1, json2);
+	}
+
+	static void compareJson(String s1Json, String s2aJson, String s2bJson) throws IOException {
+		compareJson(s1Json, s2aJson);
+		compareJson(s2aJson, s2bJson);
+	}
+
+	static void compareJson(String s1Json, String s2Json) throws IOException {
+		ObjectMapper om = new ObjectMapper();
+		om.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+		om.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+		JsonNode s1Tree = om.readTree(s1Json);
+		JsonNode s2Tree = om.readTree(s2Json);
+		if (!s1Tree.equals(s2Tree)) {
+			JsonNode patch12 = JsonDiff.asJson(s1Tree, s2Tree);
+			JsonNode patch21 = JsonDiff.asJson(s2Tree, s1Tree);
+			fail(String.format("Not equivalent JSON:%n%s%n%s%n%s%n%s",
+					toSortedString(om, s1Tree), toSortedString(om, s2Tree),
+					patch12.toString(), patch21.toString()));
+		}
+	}
+
+	static String toSortedString(ObjectMapper om, JsonNode node) throws JsonProcessingException {
+		final Object obj = om.treeToValue(node, Object.class);
+		return om.writeValueAsString(obj);
+	}
+}

--- a/radixdlt-java/src/test/java/com/radixdlt/client/util/SerializeObjectEngine.java
+++ b/radixdlt-java/src/test/java/com/radixdlt/client/util/SerializeObjectEngine.java
@@ -1,0 +1,92 @@
+/*
+ *
+ *  * (C) Copyright 2020 Radix DLT Ltd
+ *  *
+ *  * Radix DLT Ltd licenses this file to you under the Apache License,
+ *  * Version 2.0 (the "License"); you may not use this file except in
+ *  * compliance with the License.  You may obtain a copy of the
+ *  * License at
+ *  *
+ *  *  http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  * either express or implied.  See the License for the specific
+ *  * language governing permissions and limitations under the License.
+ *
+ */
+
+package com.radixdlt.client.util;
+
+import com.radixdlt.serialization.DsonOutput;
+import com.radixdlt.serialization.Polymorphic;
+import com.radixdlt.serialization.Serialization;
+import com.radixdlt.serialization.core.ClasspathScanningSerializationPolicy;
+import com.radixdlt.serialization.core.ClasspathScanningSerializerIds;
+import org.junit.Test;
+
+import java.util.function.Supplier;
+
+import static com.radixdlt.client.util.SerializationTestUtilsEngine.testEncodeDecode;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
+
+/**
+ * N.B. this was copied (duplication :/ ) over from `radixdlt-java-common`,
+ * we should remove this code duplication in the future, <a href="https://radixdlt.atlassian.net/browse/RPNV1-83">here is Jira ticket
+ *  * relating to this task.<a/>
+ *
+ * Raft of tests for serialization of objects.
+ * <p>
+ * Note that the tests that round-trip types through the serializer
+ * are not run for {@link Polymorphic} types, as these types do not
+ * serialize to themselves, but to one of their superclasses.
+ *
+ * @param <T> The type under test.
+ */
+public abstract class SerializeObjectEngine<T> {
+
+	private final Class<T> cls;
+	private final Supplier<T> factory;
+	private final Serialization serialization = Serialization.create(
+			ClasspathScanningSerializerIds.create(),
+			ClasspathScanningSerializationPolicy.create()
+	);
+
+
+	protected SerializeObjectEngine(Class<T> cls, Supplier<T> factory) {
+		this.cls = cls;
+		this.factory = factory;
+	}
+
+	@Test
+	public void from_engine___testNONEIsEmpty() throws Exception {
+		String s2Json = this.serialization.toJson(factory.get(), DsonOutput.Output.NONE);
+		assertEquals("{}", s2Json);
+	}
+
+	@Test
+	public void from_engine___testEncodeDecodeALL() throws Exception {
+		assumeFalse("Not applicable for polymorphic classes", Polymorphic.class.isAssignableFrom(cls));
+		testEncodeDecode(factory.get(), cls, this.serialization, DsonOutput.Output.ALL);
+	}
+
+	@Test
+	public void from_engine___testEncodeDecodeAPI() throws Exception {
+		assumeFalse("Not applicable for polymorphic classes", Polymorphic.class.isAssignableFrom(cls));
+		testEncodeDecode(factory.get(), cls, this.serialization, DsonOutput.Output.API);
+	}
+
+	@Test
+	public void from_engine___testEncodeDecodePERSIST() throws Exception {
+		assumeFalse("Not applicable for polymorphic classes", Polymorphic.class.isAssignableFrom(cls));
+		testEncodeDecode(factory.get(), cls, this.serialization, DsonOutput.Output.PERSIST);
+	}
+
+	@Test
+	public void from_engine___testEncodeDecodeWIRE() throws Exception {
+		assumeFalse("Not applicable for polymorphic classes", Polymorphic.class.isAssignableFrom(cls));
+		testEncodeDecode(factory.get(), cls, this.serialization, DsonOutput.Output.WIRE);
+	}
+}


### PR DESCRIPTION
Adds support for basic delegated staking by introducing a new `StakedTokensParticle` state for instantiated tokens. Specifically, this adds transitions as described [in our design](https://radixdlt.atlassian.net/wiki/spaces/RPNV1/pages/851640333/Proof+Of+Stake+v1):
- Stake owned tokens to a delegate (`Transferrable` -> `Staked` via `stakeTokens` methods)
- Redelegate staked tokens from a delegate to another delegate (`Staked` -> `Staked` via `redelegateStakedTokens` methods)
- Unstake staked tokens from a delegate (`Staked` -> `Transferrable` via `unstakeTokens` methods)
Of course, all the usable fungible/ownable constraints apply. 