### PR TITLE
Add `url` to fixed and mutable token supply definitions

### DIFF
--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/RadixApplicationAPI.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/RadixApplicationAPI.java
@@ -564,7 +564,8 @@ public class RadixApplicationAPI {
 		String name,
 		String description,
 		String iconUrl,
-		String url) {
+		String url
+	) {
 		final CreateTokenAction tokenCreation = CreateTokenAction.create(
 			tokenRRI,
 			name,

--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/RadixApplicationAPI.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/RadixApplicationAPI.java
@@ -545,7 +545,7 @@ public class RadixApplicationAPI {
 		String name,
 		String description
 	) {
-		return createMultiIssuanceToken(tokenRRI, name, description, null);
+		return createMultiIssuanceToken(tokenRRI, name, description, null, null);
 	}
 
 	/**
@@ -556,19 +556,21 @@ public class RadixApplicationAPI {
 	 * @param name        The name of the token to create
 	 * @param description A description of the token
 	 * @param iconUrl     The URL for the token's icon
+	 * @param url         The URL for the token
 	 * @return result of the transaction
 	 */
 	public Result createMultiIssuanceToken(
 		RRI tokenRRI,
 		String name,
 		String description,
-		String iconUrl
-	) {
+		String iconUrl,
+		String url) {
 		final CreateTokenAction tokenCreation = CreateTokenAction.create(
 			tokenRRI,
 			name,
 			description,
 			iconUrl,
+			url,
 			BigDecimal.ZERO,
 			TokenUnitConversions.getMinimumGranularity(),
 			TokenSupplyType.MUTABLE
@@ -592,7 +594,7 @@ public class RadixApplicationAPI {
 		String description,
 		BigDecimal supply
 	) {
-		return createFixedSupplyToken(tokenRRI, name, description, null, supply);
+		return createFixedSupplyToken(tokenRRI, name, description, null, null, supply);
 	}
 
 	/**
@@ -603,6 +605,7 @@ public class RadixApplicationAPI {
 	 * @param name        The name of the token to create
 	 * @param description A description of the token
 	 * @param iconUrl     The URL for the token's icon
+	 * @param url         The URL for the token
 	 * @param supply      The supply of the created token
 	 * @return result of the transaction
 	 */
@@ -611,6 +614,7 @@ public class RadixApplicationAPI {
 		String name,
 		String description,
 		String iconUrl,
+		String url,
 		BigDecimal supply
 	) {
 		final CreateTokenAction tokenCreation = CreateTokenAction.create(
@@ -618,6 +622,7 @@ public class RadixApplicationAPI {
 			name,
 			description,
 			iconUrl,
+			url,
 			supply,
 			TokenUnitConversions.getMinimumGranularity(),
 			TokenSupplyType.FIXED
@@ -644,7 +649,7 @@ public class RadixApplicationAPI {
 		BigDecimal granularity,
 		TokenSupplyType tokenSupplyType
 	) {
-		return createToken(tokenRRI, name, description, null, initialSupply, granularity, tokenSupplyType);
+		return createToken(tokenRRI, name, description, null, null, initialSupply, granularity, tokenSupplyType);
 	}
 
 	/**
@@ -654,6 +659,7 @@ public class RadixApplicationAPI {
 	 * @param name            The name of the token to create
 	 * @param description     A description of the token
 	 * @param iconUrl         The URL for the token's icon
+	 * @param url             The URL For the otken
 	 * @param initialSupply   The initial amount of supply for this token
 	 * @param granularity     The least multiple of subunits per transaction for this token
 	 * @param tokenSupplyType The type of supply for this token: Fixed or Mutable
@@ -664,6 +670,7 @@ public class RadixApplicationAPI {
 		String name,
 		String description,
 		String iconUrl,
+		String url,
 		BigDecimal initialSupply,
 		BigDecimal granularity,
 		TokenSupplyType tokenSupplyType
@@ -673,6 +680,7 @@ public class RadixApplicationAPI {
 			name,
 			description,
 			iconUrl,
+			url,
 			initialSupply,
 			granularity,
 			tokenSupplyType

--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/CreateTokenAction.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/CreateTokenAction.java
@@ -38,6 +38,7 @@ public class CreateTokenAction implements Action {
 	private final RRI rri;
 	private final String description;
 	private final String iconUrl;
+	private final String url;
 	private final BigDecimal initialSupply;
 	private final BigDecimal granularity;
 	private final TokenSupplyType tokenSupplyType;
@@ -47,6 +48,7 @@ public class CreateTokenAction implements Action {
 		String name,
 		String description,
 		String iconUrl,
+		String url,
 		BigDecimal initialSupply,
 		BigDecimal granularity,
 		TokenSupplyType tokenSupplyType
@@ -66,6 +68,7 @@ public class CreateTokenAction implements Action {
 		this.rri = Objects.requireNonNull(rri);
 		this.description = description;
 		this.iconUrl = iconUrl;
+		this.url = url;
 		this.initialSupply = initialSupply;
 		this.granularity = Objects.requireNonNull(granularity);
 		this.tokenSupplyType = Objects.requireNonNull(tokenSupplyType);
@@ -76,11 +79,12 @@ public class CreateTokenAction implements Action {
 		String name,
 		String description,
 		String iconUrl,
+		String url,
 		BigDecimal initialSupply,
 		BigDecimal granularity,
 		TokenSupplyType tokenSupplyType
 	) {
-		return new CreateTokenAction(tokenRRI, name, description, iconUrl, initialSupply, granularity, tokenSupplyType);
+		return new CreateTokenAction(tokenRRI, name, description, iconUrl, url, initialSupply, granularity, tokenSupplyType);
 	}
 
 	public static CreateTokenAction create(
@@ -91,7 +95,7 @@ public class CreateTokenAction implements Action {
 		BigDecimal granularity,
 		TokenSupplyType tokenSupplyType
 	) {
-		return create(tokenRRI, name, description, null, initialSupply, granularity, tokenSupplyType);
+		return create(tokenRRI, name, description, null, null, initialSupply, granularity, tokenSupplyType);
 	}
 
 	public RRI getRRI() {
@@ -108,6 +112,10 @@ public class CreateTokenAction implements Action {
 
 	public String getIconUrl() {
 		return iconUrl;
+	}
+
+	public String getUrl() {
+		return url;
 	}
 
 	public BigDecimal getInitialSupply() {

--- a/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/CreateTokenToParticleGroupsMapper.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/application/translate/tokens/CreateTokenToParticleGroupsMapper.java
@@ -69,7 +69,8 @@ public class CreateTokenToParticleGroupsMapper implements StatelessActionToParti
 				TokenTransition.MINT, TokenPermission.TOKEN_OWNER_ONLY,
 				TokenTransition.BURN, TokenPermission.TOKEN_OWNER_ONLY
 			),
-			tokenCreation.getIconUrl()
+			tokenCreation.getIconUrl(),
+			tokenCreation.getUrl()
 		);
 
 		UnallocatedTokensParticle unallocated = new UnallocatedTokensParticle(
@@ -138,7 +139,8 @@ public class CreateTokenToParticleGroupsMapper implements StatelessActionToParti
 			tokenCreation.getDescription(),
 			amount,
 			granularity,
-			tokenCreation.getIconUrl()
+			tokenCreation.getIconUrl(),
+			tokenCreation.getUrl()
 		);
 
 		TransferrableTokensParticle tokens = new TransferrableTokensParticle(

--- a/radixdlt-java/src/main/java/com/radixdlt/client/atommodel/tokens/FixedSupplyTokenDefinitionParticle.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/atommodel/tokens/FixedSupplyTokenDefinitionParticle.java
@@ -80,7 +80,8 @@ public final class FixedSupplyTokenDefinitionParticle extends Particle implement
 		UInt256 supply,
 		UInt256 granularity,
 		String iconUrl,
-		String url) {
+		String url
+	) {
 		this(RRI.of(address,  symbol), name, description, supply, granularity, iconUrl, url);
 	}
 
@@ -91,7 +92,8 @@ public final class FixedSupplyTokenDefinitionParticle extends Particle implement
 		UInt256 supply,
 		UInt256 granularity,
 		String iconUrl,
-		String url) {
+		String url
+	) {
 		super(rri.getAddress().euid());
 
 		this.rri = rri;

--- a/radixdlt-java/src/main/java/com/radixdlt/client/atommodel/tokens/FixedSupplyTokenDefinitionParticle.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/atommodel/tokens/FixedSupplyTokenDefinitionParticle.java
@@ -63,6 +63,10 @@ public final class FixedSupplyTokenDefinitionParticle extends Particle implement
 	@DsonOutput(Output.ALL)
 	private String iconUrl;
 
+	@JsonProperty("url")
+	@DsonOutput(Output.ALL)
+	private String url;
+
 	FixedSupplyTokenDefinitionParticle() {
 		// For serializer only
 		super();
@@ -75,9 +79,9 @@ public final class FixedSupplyTokenDefinitionParticle extends Particle implement
 		String description,
 		UInt256 supply,
 		UInt256 granularity,
-		String iconUrl
-	) {
-		this(RRI.of(address,  symbol), name, description, supply, granularity, iconUrl);
+		String iconUrl,
+		String url) {
+		this(RRI.of(address,  symbol), name, description, supply, granularity, iconUrl, url);
 	}
 
 	public FixedSupplyTokenDefinitionParticle(
@@ -86,8 +90,8 @@ public final class FixedSupplyTokenDefinitionParticle extends Particle implement
 		String description,
 		UInt256 supply,
 		UInt256 granularity,
-		String iconUrl
-	) {
+		String iconUrl,
+		String url) {
 		super(rri.getAddress().euid());
 
 		this.rri = rri;
@@ -96,6 +100,7 @@ public final class FixedSupplyTokenDefinitionParticle extends Particle implement
 		this.supply = Objects.requireNonNull(supply);
 		this.granularity = Objects.requireNonNull(granularity);
 		this.iconUrl = iconUrl;
+		this.url = url;
 	}
 
 	@Override
@@ -130,6 +135,10 @@ public final class FixedSupplyTokenDefinitionParticle extends Particle implement
 
 	public String getIconUrl() {
 		return this.iconUrl;
+	}
+
+	public String getUrl() {
+		return url;
 	}
 
 	@Override

--- a/radixdlt-java/src/main/java/com/radixdlt/client/atommodel/tokens/MutableSupplyTokenDefinitionParticle.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/atommodel/tokens/MutableSupplyTokenDefinitionParticle.java
@@ -65,6 +65,10 @@ public class MutableSupplyTokenDefinitionParticle extends Particle implements Id
 	@DsonOutput(Output.ALL)
 	private String iconUrl;
 
+	@JsonProperty("url")
+	@DsonOutput(Output.ALL)
+	private String url;
+
 	private Map<TokenTransition, TokenPermission> tokenPermissions;
 
 	MutableSupplyTokenDefinitionParticle() {
@@ -78,9 +82,9 @@ public class MutableSupplyTokenDefinitionParticle extends Particle implements Id
 		String description,
 		UInt256 granularity,
 		Map<TokenTransition, TokenPermission> tokenPermissions,
-		String iconUrl
-	) {
-		this(RRI.of(address, symbol), name, description, granularity, tokenPermissions, iconUrl);
+		String iconUrl,
+		String url) {
+		this(RRI.of(address, symbol), name, description, granularity, tokenPermissions, iconUrl, url);
 	}
 
 	public MutableSupplyTokenDefinitionParticle(
@@ -89,8 +93,8 @@ public class MutableSupplyTokenDefinitionParticle extends Particle implements Id
 		String description,
 		UInt256 granularity,
 		Map<TokenTransition, TokenPermission> tokenPermissions,
-		String iconUrl
-	) {
+		String iconUrl,
+		String url) {
 		super(rri.getAddress().euid());
 		this.rri = rri;
 		this.name = name;
@@ -98,6 +102,7 @@ public class MutableSupplyTokenDefinitionParticle extends Particle implements Id
 		this.granularity = granularity;
 		this.tokenPermissions = ImmutableMap.copyOf(tokenPermissions);
 		this.iconUrl = iconUrl;
+		this.url = url;
 	}
 
 	@Override
@@ -132,6 +137,10 @@ public class MutableSupplyTokenDefinitionParticle extends Particle implements Id
 
 	public String getIconUrl() {
 		return this.iconUrl;
+	}
+
+	public String getUrl() {
+		return url;
 	}
 
 	@JsonProperty("permissions")

--- a/radixdlt-java/src/main/java/com/radixdlt/client/atommodel/tokens/MutableSupplyTokenDefinitionParticle.java
+++ b/radixdlt-java/src/main/java/com/radixdlt/client/atommodel/tokens/MutableSupplyTokenDefinitionParticle.java
@@ -83,7 +83,8 @@ public class MutableSupplyTokenDefinitionParticle extends Particle implements Id
 		UInt256 granularity,
 		Map<TokenTransition, TokenPermission> tokenPermissions,
 		String iconUrl,
-		String url) {
+		String url
+	) {
 		this(RRI.of(address, symbol), name, description, granularity, tokenPermissions, iconUrl, url);
 	}
 
@@ -94,7 +95,8 @@ public class MutableSupplyTokenDefinitionParticle extends Particle implements Id
 		UInt256 granularity,
 		Map<TokenTransition, TokenPermission> tokenPermissions,
 		String iconUrl,
-		String url) {
+		String url
+	) {
 		super(rri.getAddress().euid());
 		this.rri = rri;
 		this.name = name;


### PR DESCRIPTION
Adds a generic, optional `url` field to both fixed and mutable supply token definitions. 